### PR TITLE
Fluentd Elasticsearch Auth

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.2.4
+version: 2.3.0
 appVersion: 2.4.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -49,6 +49,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `configMaps`                       | Fluentd configmaps                                                                           | `default conf files`                             |
 | `elasticsearch.host`               | Elasticsearch Host                                                                           | `elasticsearch-client`                           |
 | `elasticsearch.port`               | Elasticsearch Port                                                                           | `9200`                                           |
+| `elasticsearch.user`               | Elasticsearch Auth User                                                                      | `""`                                             |
+| `elasticsearch.password`           | Elasticsearch Auth Password                                                                  | `""`                                             |
 | `elasticsearch.logstash_prefix`    | Elasticsearch Logstash prefix                                                                | `logstash`                                       |
 | `elasticsearch.buffer_chunk_limit` | Elasticsearch buffer chunk limit                                                             | `2M`                                             |
 | `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit                                                             | `8`                                              |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -63,6 +63,10 @@ spec:
           value: {{ .Values.elasticsearch.host | quote }}
         - name: OUTPUT_PORT
           value: {{ .Values.elasticsearch.port | quote }}
+        - name: OUTPUT_USER
+          value: {{ .Values.elasticsearch.user | quote }}
+        - name: OUTPUT_PASSWORD
+          value: {{ .Values.elasticsearch.password | quote }}
         - name: LOGSTASH_PREFIX
           value: {{ .Values.elasticsearch.logstash_prefix | quote }}
         - name: OUTPUT_SCHEME

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -34,8 +34,8 @@ elasticsearch:
   port: 9200
   scheme: 'http'
   ssl_version: TLSv1_2
-  # user:
-  # password:
+  user: ""
+  password: ""
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
   logstash_prefix: 'logstash'

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -34,6 +34,8 @@ elasticsearch:
   port: 9200
   scheme: 'http'
   ssl_version: TLSv1_2
+  # user:
+  # password:
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
   logstash_prefix: 'logstash'
@@ -474,6 +476,8 @@ configMaps:
       port "#{ENV['OUTPUT_PORT']}"
       scheme "#{ENV['OUTPUT_SCHEME']}"
       ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
+      user "#{ENV['OUTPUT_USER']}"
+      password "#{ENV['OUTPUT_PASSWORD']}"
       logstash_format true
       logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
       reconnect_on_error true


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This change adds optional authentication parameters to the chart to be used with Elasticsearch instances with auth enabled (via XPack, proxy, etc.).  

#### Special notes for your reviewer:
I've tested this against an authenticated and non-authenticated cluster. Leaving the user/password parameters empty effectively ignores them.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
