### PR TITLE
Fixing liveness probe

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.3.1
+version: 2.3.2
 appVersion: 2.4.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.4.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -137,7 +137,7 @@ spec:
             - '-c'
             - >
               LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
-              STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+              STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
               if [ ! -e /var/log/fluentd-buffers ];
               then
                 exit 1;

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -45,6 +45,8 @@ elasticsearch:
 #     user "#{ENV['OUTPUT_USER']}"
 env:
   # OUTPUT_USER: my_user
+  # LIVENESS_THRESHOLD_SECONDS: 300
+  # STUCK_THRESHOLD_SECONDS: 900
 
 # If you want to add custom environment variables from secrets, use the secret list
 secret:


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fixes the `STUCK_THRESHOLD_SECONDS` variable in the liveness probe to allows it to be set via env var.  Previously it was always set to the same value as `LIVENESS_THRESHOLD_SECONDS`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
