### PR TITLE
[stable/fluentd-elasticsearch] Use config from k8s repo

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.3.3
+version: 2.4.0
 appVersion: 2.4.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -213,11 +213,21 @@ configMaps:
       @id fluentd-containers.log
       @type tail
       path /var/log/containers/*.log
-      pos_file /var/log/fluentd-containers.log.pos
-      time_format %Y-%m-%dT%H:%M:%S.%NZ
+      pos_file /var/log/containers.log.pos
       tag raw.kubernetes.*
-      format json
       read_from_head true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
     </source>
     # Detect exceptions in the log output and forward them as one log entry.
     <match raw.kubernetes.**>
@@ -230,6 +240,36 @@ configMaps:
       max_bytes 500000
       max_lines 1000
     </match>
+    # Concatenate multi-line logs
+    <filter **>
+      @id filter_concat
+      @type concat
+      key message
+      multiline_end_regexp /\n$/
+      separator ""
+    </filter>
+    # Enriches records with Kubernetes metadata
+    <filter kubernetes.**>
+      @id filter_kubernetes_metadata
+      @type kubernetes_metadata
+    </filter>
+    # Fixes json fields in Elasticsearch
+    <filter kubernetes.**>
+      @id filter_parser
+      @type parser
+      key_name log
+      reserve_data true
+      remove_key_name_field true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
   system.input.conf: |-
     # Example:
     # 2015-12-21 23:17:22,066 [salt.state       ][INFO    ] Completed state [net.ipv4.ip_forward] at time 23:17:22.066081
@@ -255,6 +295,7 @@ configMaps:
     # Examples:
     # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
     # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
+    # TODO(random-liu): Remove this after cri container runtime rolls out.
     <source>
       @id docker.log
       @type tail
@@ -349,20 +390,6 @@ configMaps:
       tag kube-scheduler
     </source>
     # Example:
-    # I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
-    <source>
-      @id rescheduler.log
-      @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\w\d{4}/
-      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
-      time_format %m%d %H:%M:%S.%N
-      path /var/log/rescheduler.log
-      pos_file /var/log/rescheduler.log.pos
-      tag rescheduler
-    </source>
-    # Example:
     # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
     <source>
       @id glbc.log
@@ -391,6 +418,7 @@ configMaps:
       tag cluster-autoscaler
     </source>
     # Logs from systemd-journal for interesting services.
+    # TODO(random-liu): Remove this after cri container runtime rolls out.
     <source>
       @id journald-docker
       @type systemd
@@ -402,6 +430,18 @@ configMaps:
       </storage>
       read_from_head true
       tag docker
+    </source>
+    <source>
+      @id journald-container-runtime
+      @type systemd
+      matches [{ "_SYSTEMD_UNIT": "{{ fluentd_container_runtime_service }}.service" }]
+      <storage>
+        @type local
+        persistent true
+        path /var/log/journald-container-runtime.pos
+      </storage>
+      read_from_head true
+      tag container-runtime
     </source>
     <source>
       @id journald-kubelet
@@ -427,22 +467,42 @@ configMaps:
       read_from_head true
       tag node-problem-detector
     </source>
+    <source>
+      @id kernel
+      @type systemd
+      matches [{ "_TRANSPORT": "kernel" }]
+      <storage>
+        @type local
+        persistent true
+        path /var/log/kernel.pos
+      </storage>
+      <entry>
+        fields_strip_underscores true
+        fields_lowercase true
+      </entry>
+      read_from_head true
+      tag kernel
+    </source>
   forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>
+      @id forward
       @type forward
     </source>
   monitoring.conf: |-
     # Prometheus Exporter Plugin
     # input plugin that exports metrics
     <source>
+      @id prometheus
       @type prometheus
     </source>
     <source>
+      @id monitor_agent
       @type monitor_agent
     </source>
     # input plugin that collects metrics from MonitorAgent
     <source>
+      @id prometheus_monitor
       @type prometheus_monitor
       <labels>
         host ${hostname}
@@ -450,6 +510,7 @@ configMaps:
     </source>
     # input plugin that collects metrics for output plugin
     <source>
+      @id prometheus_output_monitor
       @type prometheus_output_monitor
       <labels>
         host ${hostname}
@@ -457,17 +518,13 @@ configMaps:
     </source>
     # input plugin that collects metrics for in_tail plugin
     <source>
+      @id prometheus_tail_monitor
       @type prometheus_tail_monitor
       <labels>
         host ${hostname}
       </labels>
     </source>
-  output.conf: |
-    # Enriches records with Kubernetes metadata
-    <filter kubernetes.**>
-      @type kubernetes_metadata
-    </filter>
-
+  output.conf: |-
     <match **>
       @id elasticsearch
       @type elasticsearch
@@ -497,6 +554,7 @@ configMaps:
         overflow_action block
       </buffer>
     </match>
+
 
 # extraVolumes:
 #   - name: es-certs

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -518,10 +518,12 @@ configMaps:
       @id prometheus
       @type prometheus
     </source>
+    
     <source>
       @id monitor_agent
       @type monitor_agent
     </source>
+    
     # input plugin that collects metrics from MonitorAgent
     <source>
       @id prometheus_monitor
@@ -530,6 +532,7 @@ configMaps:
         host ${hostname}
       </labels>
     </source>
+    
     # input plugin that collects metrics for output plugin
     <source>
       @id prometheus_output_monitor
@@ -538,6 +541,7 @@ configMaps:
         host ${hostname}
       </labels>
     </source>
+    
     # input plugin that collects metrics for in_tail plugin
     <source>
       @id prometheus_tail_monitor

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -229,6 +229,7 @@ configMaps:
         </pattern>
       </parse>
     </source>
+
     # Detect exceptions in the log output and forward them as one log entry.
     <match raw.kubernetes.**>
       @id raw.kubernetes
@@ -240,6 +241,7 @@ configMaps:
       max_bytes 500000
       max_lines 1000
     </match>
+
     # Concatenate multi-line logs
     <filter **>
       @id filter_concat
@@ -248,11 +250,13 @@ configMaps:
       multiline_end_regexp /\n$/
       separator ""
     </filter>
+
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>
       @id filter_kubernetes_metadata
       @type kubernetes_metadata
     </filter>
+
     # Fixes json fields in Elasticsearch
     <filter kubernetes.**>
       @id filter_parser
@@ -270,6 +274,7 @@ configMaps:
         </pattern>
       </parse>
     </filter>
+
   system.input.conf: |-
     # Example:
     # 2015-12-21 23:17:22,066 [salt.state       ][INFO    ] Completed state [net.ipv4.ip_forward] at time 23:17:22.066081
@@ -282,6 +287,7 @@ configMaps:
       pos_file /var/log/salt.pos
       tag salt
     </source>
+
     # Example:
     # Dec 21 23:17:22 gke-foo-1-1-4b5cbd14-node-4eoj startupscript: Finished running startup script /var/run/google.startup.script
     <source>
@@ -292,6 +298,7 @@ configMaps:
       pos_file /var/log/startupscript.log.pos
       tag startupscript
     </source>
+
     # Examples:
     # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
     # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
@@ -304,6 +311,7 @@ configMaps:
       pos_file /var/log/docker.log.pos
       tag docker
     </source>
+
     # Example:
     # 2016/02/04 06:52:38 filePurge: successfully removed file /var/etcd/data/member/wal/00000000000006d0-00000000010a23d1.wal
     <source>
@@ -316,6 +324,7 @@ configMaps:
       pos_file /var/log/etcd.log.pos
       tag etcd
     </source>
+
     # Multi-line parsing is required for all the kube logs because very large log
     # statements, such as those that include entire object bodies, get split into
     # multiple lines by glog.
@@ -333,6 +342,7 @@ configMaps:
       pos_file /var/log/kubelet.log.pos
       tag kubelet
     </source>
+
     # Example:
     # I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
     <source>
@@ -347,6 +357,7 @@ configMaps:
       pos_file /var/log/kube-proxy.log.pos
       tag kube-proxy
     </source>
+
     # Example:
     # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
     <source>
@@ -361,6 +372,7 @@ configMaps:
       pos_file /var/log/kube-apiserver.log.pos
       tag kube-apiserver
     </source>
+
     # Example:
     # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
     <source>
@@ -375,6 +387,7 @@ configMaps:
       pos_file /var/log/kube-controller-manager.log.pos
       tag kube-controller-manager
     </source>
+
     # Example:
     # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
     <source>
@@ -389,6 +402,7 @@ configMaps:
       pos_file /var/log/kube-scheduler.log.pos
       tag kube-scheduler
     </source>
+
     # Example:
     # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
     <source>
@@ -403,8 +417,9 @@ configMaps:
       pos_file /var/log/glbc.log.pos
       tag glbc
     </source>
+
     # Example:
-    # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
+    # TODO Add a proper example here.
     <source>
       @id cluster-autoscaler.log
       @type tail
@@ -417,6 +432,7 @@ configMaps:
       pos_file /var/log/cluster-autoscaler.log.pos
       tag cluster-autoscaler
     </source>
+
     # Logs from systemd-journal for interesting services.
     # TODO(random-liu): Remove this after cri container runtime rolls out.
     <source>
@@ -431,6 +447,7 @@ configMaps:
       read_from_head true
       tag docker
     </source>
+
     <source>
       @id journald-container-runtime
       @type systemd
@@ -443,6 +460,7 @@ configMaps:
       read_from_head true
       tag container-runtime
     </source>
+
     <source>
       @id journald-kubelet
       @type systemd
@@ -455,6 +473,7 @@ configMaps:
       read_from_head true
       tag kubelet
     </source>
+
     <source>
       @id journald-node-problem-detector
       @type systemd
@@ -467,6 +486,7 @@ configMaps:
       read_from_head true
       tag node-problem-detector
     </source>
+
     <source>
       @id kernel
       @type systemd
@@ -483,12 +503,14 @@ configMaps:
       read_from_head true
       tag kernel
     </source>
+
   forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>
       @id forward
       @type forward
     </source>
+
   monitoring.conf: |-
     # Prometheus Exporter Plugin
     # input plugin that exports metrics
@@ -524,6 +546,7 @@ configMaps:
         host ${hostname}
       </labels>
     </source>
+
   output.conf: |-
     <match **>
       @id elasticsearch


### PR DESCRIPTION
#### What this PR does / why we need it:
Logs in json format not being properly parsed in kibana.
Using config as per k8s repo fixes this. Thanks to @monotek for the info.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
