### PR TITLE
Added support for Prometheus ServiceMonitor and PrometheusRule

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.4.1
+version: 2.5.0
 appVersion: 2.4.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.4.0
+version: 2.4.1
 appVersion: 2.4.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -42,48 +42,54 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd elasticsearch chart and their default values.
 
-| Parameter                          | Description                                                                                  | Default                                          |
-| ---------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `annotations`                      | Optional daemonset annotations                                                               | `NULL`                                           |
-| `podAnnotations`                   | Optional daemonset's pods annotations                                                        | `NULL`                                           |
-| `configMaps`                       | Fluentd configmaps                                                                           | `default conf files`                             |
-| `elasticsearch.host`               | Elasticsearch Host                                                                           | `elasticsearch-client`                           |
-| `elasticsearch.port`               | Elasticsearch Port                                                                           | `9200`                                           |
-| `elasticsearch.user`               | Elasticsearch Auth User                                                                      | `""`                                             |
-| `elasticsearch.password`           | Elasticsearch Auth Password                                                                  | `""`                                             |
-| `elasticsearch.logstash_prefix`    | Elasticsearch Logstash prefix                                                                | `logstash`                                       |
-| `elasticsearch.buffer_chunk_limit` | Elasticsearch buffer chunk limit                                                             | `2M`                                             |
-| `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit                                                             | `8`                                              |
-| `elasticsearch.scheme`             | Elasticsearch scheme setting                                                                 | `http`                                           |
-| `env`                              | List of environment variables that are added to the fluentd pods                             | `{}`                                             |
-| `secret`                           | List of environment variables that are set from secrets and added to the fluentd pods        | `[]`                                             |
-| `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |                                                  |
-| `extraVolume`                      | Extra volume                                                                                 |                                                  |
-| `image.repository`                 | Image                                                                                        | `gcr.io/google-containers/fluentd-elasticsearch` |
-| `image.tag`                        | Image tag                                                                                    | `v2.4.0`                                         |
-| `image.pullPolicy`                 | Image pull policy                                                                            | `IfNotPresent`                                   |
-| `image.pullSecrets`                | Image pull secrets                                                                           |                                                  |
-| `livenessProbe.enabled`            | Whether to enable livenessProbe                                                              | `true`                                           |
-| `nodeSelector`                     | Optional daemonset nodeSelector                                                              | `{}`                                             |
-| `podSecurityPolicy.annotations`    | Specify pod annotations in the pod security policy                                           | `{}`                                             |
-| `podSecurityPolicy.enabled`        | Specify if a pod security policy must be created                                             | `false`                                          |
-| `priorityClassName`                | Optional PriorityClass for pods                                                              | `""`                                             |
-| `rbac.create`                      | RBAC                                                                                         | `true`                                           |
-| `resources.limits.cpu`             | CPU limit                                                                                    | `100m`                                           |
-| `resources.limits.memory`          | Memory limit                                                                                 | `500Mi`                                          |
-| `resources.requests.cpu`           | CPU request                                                                                  | `100m`                                           |
-| `resources.requests.memory`        | Memory request                                                                               | `200Mi`                                          |
-| `service`                          | Service definition                                                                           | `{}`                                             |
-| `service.type`                     | Service type (ClusterIP/NodePort)                                                            | Not Set                                          |
-| `service.ports`                    | List of service ports dict [{name:...}...]                                                   | Not Set                                          |
-| `service.ports[].name`             | One of service ports name                                                                    | Not Set                                          |
-| `service.ports[].port`             | Service port                                                                                 | Not Set                                          |
-| `service.ports[].nodePort`         | NodePort port (when service.type is NodePort)                                                | Not Set                                          |
-| `service.ports[].protocol`         | Service protocol(optional, can be TCP/UDP)                                                   | Not Set                                          |
-| `serviceAccount.create`            | Specifies whether a service account should be created.                                       | `true`                                           |
-| `serviceAccount.name`              | Name of the service account.                                                                 |                                                  |
-| `tolerations`                      | Optional daemonset tolerations                                                               | `{}`                                             |
-| `updateStrategy`                   | Optional daemonset update strategy                                                           | `type: RollingUpdate`                            |
+| Parameter                            | Description                                                                                  | Default                                          |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `annotations`                        | Optional daemonset annotations                                                               | `NULL`                                           |
+| `podAnnotations`                     | Optional daemonset's pods annotations                                                        | `NULL`                                           |
+| `configMaps`                         | Fluentd configmaps                                                                           | `default conf files`                             |
+| `elasticsearch.host`                 | Elasticsearch Host                                                                           | `elasticsearch-client`                           |
+| `elasticsearch.port`                 | Elasticsearch Port                                                                           | `9200`                                           |
+| `elasticsearch.user`                 | Elasticsearch Auth User                                                                      | `""`                                             |
+| `elasticsearch.password`             | Elasticsearch Auth Password                                                                  | `""`                                             |
+| `elasticsearch.logstash_prefix`      | Elasticsearch Logstash prefix                                                                | `logstash`                                       |
+| `elasticsearch.buffer_chunk_limit`   | Elasticsearch buffer chunk limit                                                             | `2M`                                             |
+| `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                                             | `8`                                              |
+| `elasticsearch.scheme`               | Elasticsearch scheme setting                                                                 | `http`                                           |
+| `env`                                | List of environment variables that are added to the fluentd pods                             | `{}`                                             |
+| `secret`                             | List of environment variables that are set from secrets and added to the fluentd pods        | `[]`                                             |
+| `extraVolumeMounts`                  | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |                                                  |
+| `extraVolume`                        | Extra volume                                                                                 |                                                  |
+| `image.repository`                   | Image                                                                                        | `gcr.io/google-containers/fluentd-elasticsearch` |
+| `image.tag`                          | Image tag                                                                                    | `v2.4.0`                                         |
+| `image.pullPolicy`                   | Image pull policy                                                                            | `IfNotPresent`                                   |
+| `image.pullSecrets`                  | Image pull secrets                                                                           |                                                  |
+| `livenessProbe.enabled`              | Whether to enable livenessProbe                                                              | `true`                                           |
+| `nodeSelector`                       | Optional daemonset nodeSelector                                                              | `{}`                                             |
+| `podSecurityPolicy.annotations`      | Specify pod annotations in the pod security policy                                           | `{}`                                             |
+| `podSecurityPolicy.enabled`          | Specify if a pod security policy must be created                                             | `false`                                          |
+| `priorityClassName`                  | Optional PriorityClass for pods                                                              | `""`                                             |
+| `prometheusRule`                     | Whether to enable Prometheus prometheusRule                                                  | `false`                                          |
+| `prometheusRule.prometheusNamespace` | Namespace for prometheusRule                                                                 | `monitoring`                                     |
+| `prometheusRule.labels`              | Optional labels for prometheusRule                                                           | `{}`                                             |
+| `rbac.create`                        | RBAC                                                                                         | `true`                                           |
+| `resources.limits.cpu`               | CPU limit                                                                                    | `100m`                                           |
+| `resources.limits.memory`            | Memory limit                                                                                 | `500Mi`                                          |
+| `resources.requests.cpu`             | CPU request                                                                                  | `100m`                                           |
+| `resources.requests.memory`          | Memory request                                                                               | `200Mi`                                          |
+| `service`                            | Service definition                                                                           | `{}`                                             |
+| `service.type`                       | Service type (ClusterIP/NodePort)                                                            | Not Set                                          |
+| `service.ports`                      | List of service ports dict [{name:...}...]                                                   | Not Set                                          |
+| `service.ports[].name`               | One of service ports name                                                                    | Not Set                                          |
+| `service.ports[].port`               | Service port                                                                                 | Not Set                                          |
+| `service.ports[].nodePort`           | NodePort port (when service.type is NodePort)                                                | Not Set                                          |
+| `service.ports[].protocol`           | Service protocol(optional, can be TCP/UDP)                                                   | Not Set                                          |
+| `serviceAccount.create`              | Specifies whether a service account should be created.                                       | `true`                                           |
+| `serviceAccount.name`                | Name of the service account.                                                                 |                                                  |
+| `serviceMonitor.enabled`             | Whether to enable Prometheus serviceMonitor                                                  | `false`                                          |
+| `serviceMonitor.path`                | Path for Metrics                                                                             | `/metrics`                                       |
+| `serviceMonitor.labels`              | Optional labels for serviceMonitor                                                           | `{}`                                             |
+| `tolerations`                        | Optional daemonset tolerations                                                               | `{}`                                             |
+| `updateStrategy`                     | Optional daemonset update strategy                                                           | `type: RollingUpdate`                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -86,6 +86,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceAccount.create`              | Specifies whether a service account should be created.                                       | `true`                                           |
 | `serviceAccount.name`                | Name of the service account.                                                                 |                                                  |
 | `serviceMonitor.enabled`             | Whether to enable Prometheus serviceMonitor                                                  | `false`                                          |
+| `serviceMonitor.interval`            | Interval at which metrics should be scraped                                                  | `10s`                                            |
 | `serviceMonitor.path`                | Path for Metrics                                                                             | `/metrics`                                       |
 | `serviceMonitor.labels`              | Optional labels for serviceMonitor                                                           | `{}`                                             |
 | `tolerations`                        | Optional daemonset tolerations                                                               | `{}`                                             |

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
+    helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    {{- if .Values.prometheusRule.labels }}
+    {{- toYaml .Values.prometheusRule.labels | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Values.prometheusRule.prometheusNamespace }}
+spec:
+  groups:
+  - name: fluentd
+    rules:
+    - alert: FluentdNodeDown
+      expr: up{job="{{ .Release.Name }}"} == 0
+      for: 10m
+      labels:
+        service: fluentd
+        severity: warning
+      annotations:
+        summary: fluentd cannot be scraped
+        description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 10 minutes
+  
+    - alert: FluentdNodeDown
+      expr: up{job="{{ .Release.Name }}"} == 0
+      for: 30m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd cannot be scraped
+        description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 30 minutes
+  
+    - alert: FluentdQueueLength
+      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.3
+      for: 1m
+      labels:
+        service: fluentd
+        severity: warning
+      annotations:
+        summary: fluentd node are failing
+        description: In the last 5 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
+
+    - alert: FluentdQueueLength
+      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.5
+      for: 1m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd node are critical
+        description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
+
+    - alert: FluentdRecordsCountsHigh
+      expr: sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[5m])) BY (instance) >  (3 * sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[15m])) BY (instance))
+      for: 1m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd records count are critical
+        description: In the last 5m, records counts increased 3 times, comparing to the latest 15 min.
+
+{{- end }}

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: 10s
+  - interval: {{ .Values.serviceMonitor.interval }}
     honorLabels: true
     {{- range $port := .Values.service.ports }}
     port: {{ $port.name }}

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
+    helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: 10s
+    honorLabels: true
+    {{- range $port := .Values.service.ports }}
+    port: {{ $port.name }}
+    {{- end }} 
+    path: {{ .Values.serviceMonitor.path }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "fluentd-elasticsearch.name" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -535,12 +535,12 @@ configMaps:
       @id prometheus
       @type prometheus
     </source>
-    
+
     <source>
       @id monitor_agent
       @type monitor_agent
     </source>
-    
+
     # input plugin that collects metrics from MonitorAgent
     <source>
       @id prometheus_monitor
@@ -549,7 +549,7 @@ configMaps:
         host ${hostname}
       </labels>
     </source>
-    
+
     # input plugin that collects metrics for output plugin
     <source>
       @id prometheus_output_monitor
@@ -558,7 +558,7 @@ configMaps:
         host ${hostname}
       </labels>
     </source>
-    
+
     # input plugin that collects metrics for in_tail plugin
     <source>
       @id prometheus_tail_monitor

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -111,6 +111,7 @@ serviceMonitor:
   ## https://github.com/coreos/prometheus-operator
   ##
   enabled: false
+  interval: 10s
   path: /metrics
   labels: {}
 

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -106,6 +106,23 @@ service: {}
   #   - name: "monitor-agent"
   #     port: 24231
 
+serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  path: /metrics
+  labels: {}
+
+prometheusRule:
+  ## If true, a PrometheusRule CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  prometheusNamespace: monitoring
+  labels: {}
+  #  role: alert-rules
+
 configMaps:
   system.conf: |-
     <system>


### PR DESCRIPTION
Signed-off-by: Pavel Zilke <zidex@altlinux.org>

#### What this PR does / why we need it:

Added templates for ServiceMonitor and PrometheusRule to fluentd-elasticsearch chart


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
