### PR TITLE
raised image version to 2.5.0

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluentd-elasticsearch
-version: 2.7.0
-appVersion: 2.4.0
+version: 2.8.0
+appVersion: 2.5.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -42,56 +42,56 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd elasticsearch chart and their default values.
 
-| Parameter                            | Description                                                                                  | Default                                          |
-| ------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `affinity`                           | Optional daemonset affinity                                                                  | `{}`                                             |
-| `annotations`                        | Optional daemonset annotations                                                               | `NULL`                                           |
-| `podAnnotations`                     | Optional daemonset's pods annotations                                                        | `NULL`                                           |
-| `configMaps`                         | Fluentd configmaps                                                                           | `default conf files`                             |
-| `elasticsearch.host`                 | Elasticsearch Host                                                                           | `elasticsearch-client`                           |
-| `elasticsearch.port`                 | Elasticsearch Port                                                                           | `9200`                                           |
-| `elasticsearch.user`                 | Elasticsearch Auth User                                                                      | `""`                                             |
-| `elasticsearch.password`             | Elasticsearch Auth Password                                                                  | `""`                                             |
-| `elasticsearch.logstash_prefix`      | Elasticsearch Logstash prefix                                                                | `logstash`                                       |
-| `elasticsearch.buffer_chunk_limit`   | Elasticsearch buffer chunk limit                                                             | `2M`                                             |
-| `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                                             | `8`                                              |
-| `elasticsearch.scheme`               | Elasticsearch scheme setting                                                                 | `http`                                           |
-| `env`                                | List of env vars that are added to the fluentd pods                             | `{}`                                             |
-| `secret`                             | List of env vars that are set from secrets and added to the fluentd pods        | `[]`                                             |
-| `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                                  |
-| `extraVolume`                        | Extra volume                                                                                 |                                                  |
-| `image.repository`                   | Image                                                                                        | `gcr.io/google-containers/fluentd-elasticse` |
-| `image.tag`                          | Image tag                                                                                    | `v2.5.0`                                         |
-| `image.pullPolicy`                   | Image pull policy                                                                            | `IfNotPresent`                                   |
-| `image.pullSecrets`                  | Image pull secrets                                                                           |                                                  |
-| `livenessProbe.enabled`              | Whether to enable livenessProbe                                                              | `true`                                           |
-| `nodeSelector`                       | Optional daemonset nodeSelector                                                              | `{}`                                             |
-| `podSecurityPolicy.annotations`      | Specify pod annotations in the pod security policy                                           | `{}`                                             |
-| `podSecurityPolicy.enabled`          | Specify if a pod security policy must be created                                             | `false`                                          |
-| `priorityClassName`                  | Optional PriorityClass for pods                                                              | `""`                                             |
-| `prometheusRule`                     | Whether to enable Prometheus prometheusRule                                                  | `false`                                          |
-| `prometheusRule.prometheusNamespace` | Namespace for prometheusRule                                                                 | `monitoring`                                     |
-| `prometheusRule.labels`              | Optional labels for prometheusRule                                                           | `{}`                                             |
-| `rbac.create`                        | RBAC                                                                                         | `true`                                           |
-| `resources.limits.cpu`               | CPU limit                                                                                    | `100m`                                           |
-| `resources.limits.memory`            | Memory limit                                                                                 | `500Mi`                                          |
-| `resources.requests.cpu`             | CPU request                                                                                  | `100m`                                           |
-| `resources.requests.memory`          | Memory request                                                                               | `200Mi`                                          |
-| `service`                            | Service definition                                                                           | `{}`                                             |
-| `service.type`                       | Service type (ClusterIP/NodePort)                                                            | Not Set                                          |
-| `service.ports`                      | List of service ports dict [{name:...}...]                                                   | Not Set                                          |
-| `service.ports[].name`               | One of service ports name                                                                    | Not Set                                          |
-| `service.ports[].port`               | Service port                                                                                 | Not Set                                          |
-| `service.ports[].nodePort`           | NodePort port (when service.type is NodePort)                                                | Not Set                                          |
-| `service.ports[].protocol`           | Service protocol(optional, can be TCP/UDP)                                                   | Not Set                                          |
-| `serviceAccount.create`              | Specifies whether a service account should be created.                                       | `true`                                           |
-| `serviceAccount.name`                | Name of the service account.                                                                 |                                                  |
-| `serviceMonitor.enabled`             | Whether to enable Prometheus serviceMonitor                                                  | `false`                                          |
-| `serviceMonitor.interval`            | Interval at which metrics should be scraped                                                  | `10s`                                            |
-| `serviceMonitor.path`                | Path for Metrics                                                                             | `/metrics`                                       |
-| `serviceMonitor.labels`              | Optional labels for serviceMonitor                                                           | `{}`                                             |
-| `tolerations`                        | Optional daemonset tolerations                                                               | `{}`                                             |
-| `updateStrategy`                     | Optional daemonset update strategy                                                           | `type: RollingUpdate`                            |
+| Parameter                            | Description                                                                    | Default                                |
+| ------------------------------------ | ------------------------------------------------------------------------------ | -------------------------------------- |
+| `affinity`                           | Optional daemonset affinity                                                    | `{}`                                   |
+| `annotations`                        | Optional daemonset annotations                                                 | `NULL`                                 |
+| `podAnnotations`                     | Optional daemonset's pods annotations                                          | `NULL`                                 |
+| `configMaps`                         | Fluentd configmaps                                                             | `default conf files`                   |
+| `elasticsearch.host`                 | Elasticsearch Host                                                             | `elasticsearch-client`                 |
+| `elasticsearch.port`                 | Elasticsearch Port                                                             | `9200`                                 |
+| `elasticsearch.user`                 | Elasticsearch Auth User                                                        | `""`                                   |
+| `elasticsearch.password`             | Elasticsearch Auth Password                                                    | `""`                                   |
+| `elasticsearch.logstash_prefix`      | Elasticsearch Logstash prefix                                                  | `logstash`                             |
+| `elasticsearch.buffer_chunk_limit`   | Elasticsearch buffer chunk limit                                               | `2M`                                   |
+| `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                               | `8`                                    |
+| `elasticsearch.scheme`               | Elasticsearch scheme setting                                                   | `http`                                 |
+| `env`                                | List of env vars that are added to the fluentd pods                            | `{}`                                   |
+| `secret`                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
+| `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                        |
+| `extraVolume`                        | Extra volume                                                                   |                                        |
+| `image.repository`                   | Image                                                                          | `gcr.io/fluentd-elasticsearch/fluentd` |
+| `image.tag`                          | Image tag                                                                      | `v2.5.0`                               |
+| `image.pullPolicy`                   | Image pull policy                                                              | `IfNotPresent`                         |
+| `image.pullSecrets`                  | Image pull secrets                                                             |                                        |
+| `livenessProbe.enabled`              | Whether to enable livenessProbe                                                | `true`                                 |
+| `nodeSelector`                       | Optional daemonset nodeSelector                                                | `{}`                                   |
+| `podSecurityPolicy.annotations`      | Specify pod annotations in the pod security policy                             | `{}`                                   |
+| `podSecurityPolicy.enabled`          | Specify if a pod security policy must be created                               | `false`                                |
+| `priorityClassName`                  | Optional PriorityClass for pods                                                | `""`                                   |
+| `prometheusRule`                     | Whether to enable Prometheus prometheusRule                                    | `false`                                |
+| `prometheusRule.prometheusNamespace` | Namespace for prometheusRule                                                   | `monitoring`                           |
+| `prometheusRule.labels`              | Optional labels for prometheusRule                                             | `{}`                                   |
+| `rbac.create`                        | RBAC                                                                           | `true`                                 |
+| `resources.limits.cpu`               | CPU limit                                                                      | `100m`                                 |
+| `resources.limits.memory`            | Memory limit                                                                   | `500Mi`                                |
+| `resources.requests.cpu`             | CPU request                                                                    | `100m`                                 |
+| `resources.requests.memory`          | Memory request                                                                 | `200Mi`                                |
+| `service`                            | Service definition                                                             | `{}`                                   |
+| `service.type`                       | Service type (ClusterIP/NodePort)                                              | Not Set                                |
+| `service.ports`                      | List of service ports dict [{name:...}...]                                     | Not Set                                |
+| `service.ports[].name`               | One of service ports name                                                      | Not Set                                |
+| `service.ports[].port`               | Service port                                                                   | Not Set                                |
+| `service.ports[].nodePort`           | NodePort port (when service.type is NodePort)                                  | Not Set                                |
+| `service.ports[].protocol`           | Service protocol(optional, can be TCP/UDP)                                     | Not Set                                |
+| `serviceAccount.create`              | Specifies whether a service account should be created.                         | `true`                                 |
+| `serviceAccount.name`                | Name of the service account.                                                   |                                        |
+| `serviceMonitor.enabled`             | Whether to enable Prometheus serviceMonitor                                    | `false`                                |
+| `serviceMonitor.interval`            | Interval at which metrics should be scraped                                    | `10s`                                  |
+| `serviceMonitor.path`                | Path for Metrics                                                               | `/metrics`                             |
+| `serviceMonitor.labels`              | Optional labels for serviceMonitor                                             | `{}`                                   |
+| `tolerations`                        | Optional daemonset tolerations                                                 | `{}`                                   |
+| `updateStrategy`                     | Optional daemonset update strategy                                             | `type: RollingUpdate`                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -107,4 +107,4 @@ $ helm install --name my-release -f values.yaml kiwigrid/fluentd-elasticsearch
 
 ## Upgrading
 
-When you upgrade this chart from a version < 2.0.0 you have to add the "--force" parameter to your helm upgrade command as there have been changes to the lables which makes a normal upgrade impossible.
+When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--force" parameter to your helm upgrade command as there have been changes to the lables which makes a normal upgrade impossible.

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.buffer_chunk_limit`   | Elasticsearch buffer chunk limit                                                             | `2M`                                             |
 | `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                                             | `8`                                              |
 | `elasticsearch.scheme`               | Elasticsearch scheme setting                                                                 | `http`                                           |
-| `env`                                | List of environment variables that are added to the fluentd pods                             | `{}`                                             |
-| `secret`                             | List of environment variables that are set from secrets and added to the fluentd pods        | `[]`                                             |
-| `extraVolumeMounts`                  | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |                                                  |
+| `env`                                | List of env vars that are added to the fluentd pods                             | `{}`                                             |
+| `secret`                             | List of env vars that are set from secrets and added to the fluentd pods        | `[]`                                             |
+| `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                                  |
 | `extraVolume`                        | Extra volume                                                                                 |                                                  |
-| `image.repository`                   | Image                                                                                        | `gcr.io/google-containers/fluentd-elasticsearch` |
-| `image.tag`                          | Image tag                                                                                    | `v2.4.0`                                         |
+| `image.repository`                   | Image                                                                                        | `gcr.io/google-containers/fluentd-elasticse` |
+| `image.tag`                          | Image tag                                                                                    | `v2.5.0`                                         |
 | `image.pullPolicy`                   | Image pull policy                                                                            | `IfNotPresent`                                   |
 | `image.pullSecrets`                  | Image pull secrets                                                                           |                                                  |
 | `livenessProbe.enabled`              | Whether to enable livenessProbe                                                              | `true`                                           |

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fluentd-elasticsearch.serviceAccountName" . }}
+  name: {{ if .Values.serviceAccount.name }}{{ .Values.serviceAccount.name }}{{ else }}{{ include "fluentd-elasticsearch.fullname" . }}{{ end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "fluentd-elasticsearch.fullname" . }}
+  name: {{ if .Values.serviceAccount.name }}{{ .Values.serviceAccount.name }}{{ else }}{{ include "fluentd-elasticsearch.fullname" . }}{{ end }}
   labels:
     app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -1,9 +1,9 @@
 image:
-  repository: gcr.io/google-containers/fluentd-elasticsearch
+  repository: gcr.io/fluentd-elasticsearch/fluentd
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
-  tag: v2.4.0
+  tag: v2.5.0
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -62,7 +62,7 @@ serviceAccount:
   create: true
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
+  name: ""
 
 ## Specify if a Pod Security Policy for node-exporter must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@kiwigrid.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
* changed image location to gcr.io/fluentd-elasticsearch/fluentd
* raised image version to 2.5.0
* fixed serviceaccountname
* shortened readme descriptions a bit to save table space

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/kiwigrid/helm-charts/issues/63#issuecomment-476866856


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
