### PR TITLE
Added support for deploying a sidecar for signing requests sent to Amazon AWS Elasticsearch.

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.8.4
+version: 2.9.0
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.8.3
+version: 2.8.4
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -114,4 +114,4 @@ When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--for
 
 ## AWS Elasticsearch Domains
 
-AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: true` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: {enabled: true}` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -48,7 +48,9 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `annotations`                        | Optional daemonset annotations                                                 | `NULL`                                 |
 | `podAnnotations`                     | Optional daemonset's pods annotations                                          | `NULL`                                 |
 | `configMaps`                         | Fluentd configmaps                                                             | `default conf files`                   |
-| `awsSigningSidecar`                  | Enable AWS request signing sidecar                                             | `false`                                |
+| `awsSigningSidecar.enabled`          | Enable AWS request signing sidecar                                             | `false`                                |
+| `awsSigningSidecar.image.repository` | AWS signing sidecard repository image                                          | `abutaha/aws-es-proxy`                 |
+| `awsSigningSidecar.image.tag`        | AWS signing sidecard repository tag                                            | `0.9`                                  |
 | `elasticsearch.host`                 | Elasticsearch Host                                                             | `elasticsearch-client`                 |
 | `elasticsearch.port`                 | Elasticsearch Port                                                             | `9200`                                 |
 | `elasticsearch.user`                 | Elasticsearch Auth User                                                        | `""`                                   |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `annotations`                        | Optional daemonset annotations                                                 | `NULL`                                 |
 | `podAnnotations`                     | Optional daemonset's pods annotations                                          | `NULL`                                 |
 | `configMaps`                         | Fluentd configmaps                                                             | `default conf files`                   |
-| `aws`                                | Enable AWS request signing sidecar                                             | `false`                                |
+| `awsSigningSidecar`                  | Enable AWS request signing sidecar                                             | `false`                                |
 | `elasticsearch.host`                 | Elasticsearch Host                                                             | `elasticsearch-client`                 |
 | `elasticsearch.port`                 | Elasticsearch Port                                                             | `9200`                                 |
 | `elasticsearch.user`                 | Elasticsearch Auth User                                                        | `""`                                   |
@@ -112,4 +112,4 @@ When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--for
 
 ## AWS Elasticsearch Domains
 
-AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `aws: true` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: true` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `annotations`                        | Optional daemonset annotations                                                 | `NULL`                                 |
 | `podAnnotations`                     | Optional daemonset's pods annotations                                          | `NULL`                                 |
 | `configMaps`                         | Fluentd configmaps                                                             | `default conf files`                   |
+| `aws`                                | Enable AWS request signing sidecar                                             | `false`                                |
 | `elasticsearch.host`                 | Elasticsearch Host                                                             | `elasticsearch-client`                 |
 | `elasticsearch.port`                 | Elasticsearch Port                                                             | `9200`                                 |
 | `elasticsearch.user`                 | Elasticsearch Auth User                                                        | `""`                                   |
@@ -108,3 +109,7 @@ $ helm install --name my-release -f values.yaml kiwigrid/fluentd-elasticsearch
 ## Upgrading
 
 When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--force" parameter to your helm upgrade command as there have been changes to the lables which makes a normal upgrade impossible.
+
+## AWS Elasticsearch Domains
+
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `aws: true` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -60,13 +60,13 @@ spec:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q
         - name: OUTPUT_HOST
-          {{- if .Values.awsSigningSidecar }}
+          {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'
           {{- else }}
           value: {{ .Values.elasticsearch.host | quote }}
           {{- end }}
         - name: OUTPUT_PORT
-          {{- if .Values.awsSigningSidecar }}
+          {{- if .Values.awsSigningSidecar.enabled }}
           value: '8080'
           {{- else }}
           value: {{ .Values.elasticsearch.port | quote }}
@@ -78,7 +78,7 @@ spec:
         - name: LOGSTASH_PREFIX
           value: {{ .Values.elasticsearch.logstash_prefix | quote }}
         - name: OUTPUT_SCHEME
-          {{- if .Values.awsSigningSidecar }}
+          {{- if .Values.awsSigningSidecar.enabled }}
           value: 'http'
           {{- else }}
           value: {{ .Values.elasticsearch.scheme | quote }}
@@ -121,9 +121,9 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
-      {{- if .Values.awsSigningSidecar }}
+      {{- if .Values.awsSigningSidecar.enabled }}
       - name: {{ include "fluentd-elasticsearch.fullname" . }}-aws-es-proxy
-        image: abutaha/aws-es-proxy:0.9
+        image: {{ .Values.awsSigningSidecar.image.repository }}:{{ .Values.awsSigningSidecar.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         args: ["-endpoint", "{{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}",
                "-listen",   "127.0.0.1:8080"]

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -60,13 +60,13 @@ spec:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q
         - name: OUTPUT_HOST
-          {{- if .Values.aws }}
+          {{- if .Values.awsSigningSidecar }}
           value: 'localhost'
           {{- else }}
           value: {{ .Values.elasticsearch.host | quote }}
           {{- end }}
         - name: OUTPUT_PORT
-          {{- if .Values.aws }}
+          {{- if .Values.awsSigningSidecar }}
           value: '8080'
           {{- else }}
           value: {{ .Values.elasticsearch.port | quote }}
@@ -78,7 +78,7 @@ spec:
         - name: LOGSTASH_PREFIX
           value: {{ .Values.elasticsearch.logstash_prefix | quote }}
         - name: OUTPUT_SCHEME
-          {{- if .Values.aws }}
+          {{- if .Values.awsSigningSidecar }}
           value: 'http'
           {{- else }}
           value: {{ .Values.elasticsearch.scheme | quote }}
@@ -121,7 +121,7 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
-      {{- if .Values.aws }}
+      {{- if .Values.awsSigningSidecar }}
       - name: {{ include "fluentd-elasticsearch.fullname" . }}-aws-es-proxy
         image: abutaha/aws-es-proxy:0.9
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -60,9 +60,17 @@ spec:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q
         - name: OUTPUT_HOST
+          {{- if .Values.aws }}
+          value: 'localhost'
+          {{- else }}
           value: {{ .Values.elasticsearch.host | quote }}
+          {{- end }}
         - name: OUTPUT_PORT
+          {{- if .Values.aws }}
+          value: '8080'
+          {{- else }}
           value: {{ .Values.elasticsearch.port | quote }}
+          {{- end }}
         - name: OUTPUT_USER
           value: {{ .Values.elasticsearch.user | quote }}
         - name: OUTPUT_PASSWORD
@@ -70,7 +78,11 @@ spec:
         - name: LOGSTASH_PREFIX
           value: {{ .Values.elasticsearch.logstash_prefix | quote }}
         - name: OUTPUT_SCHEME
+          {{- if .Values.aws }}
+          value: 'http'
+          {{- else }}
           value: {{ .Values.elasticsearch.scheme | quote }}
+          {{- end }}
         - name: OUTPUT_SSL_VERSION
           value: {{ .Values.elasticsearch.ssl_version | quote }}
         - name: OUTPUT_BUFFER_CHUNK_LIMIT
@@ -109,6 +121,16 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
+      {{- if .Values.aws }}
+      - name: {{ include "fluentd-elasticsearch.fullname" . }}-aws-es-proxy
+        image: abutaha/aws-es-proxy:0.9
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        args: ["-endpoint", "{{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}",
+               "-listen",   "127.0.0.1:8080"]
+        env:
+        - name: PORT_NUM
+          value: "{{ .Values.elasticsearch.port }}"
+      {{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -15,7 +15,11 @@ image:
 ## If using AWS Elasticsearch, all requests to ES need to be signed regardless of whether
 ## one is using Cognito or not. By setting this to true, this chart will install a sidecar
 ## proxy that takes care of signing all requests being sent to the AWS ES Domain.
-# awsSigningSidecar: true
+awsSigningSidecar:
+  enabled: false
+  image: 
+    repository: abutaha/aws-es-proxy
+    tag: 0.9
 
 # Specify to use specific priorityClass for pods
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -12,6 +12,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+## If using AWS Elasticsearch, all requests to ES need to be signed regardless of whether
+## one is using Cognito or not. By setting this to true, this chart will install a sidecar
+## proxy that takes care of signing all requests being sent to the AWS ES Domain.
+# aws: true
+
 # Specify to use specific priorityClass for pods
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -15,7 +15,7 @@ image:
 ## If using AWS Elasticsearch, all requests to ES need to be signed regardless of whether
 ## one is using Cognito or not. By setting this to true, this chart will install a sidecar
 ## proxy that takes care of signing all requests being sent to the AWS ES Domain.
-# aws: true
+# awsSigningSidecar: true
 
 # Specify to use specific priorityClass for pods
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -17,7 +17,7 @@ image:
 ## proxy that takes care of signing all requests being sent to the AWS ES Domain.
 awsSigningSidecar:
   enabled: false
-  image: 
+  image:
     repository: abutaha/aws-es-proxy
     tag: 0.9
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a new configuration `aws` of type bool that allows deploying a sidecar proxy to handle signing requests to Amazon Web Services managed Elasticsearch service.

#### Which issue this PR fixes
* See #81 (not a bug, a feature).


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
