### PR TITLE
Add fluentd args

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.10.1
+version: 2.11.0
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.10.0
+version: 2.10.1
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                               | `8`                                    |
 | `elasticsearch.scheme`               | Elasticsearch scheme setting                                                   | `http`                                 |
 | `env`                                | List of env vars that are added to the fluentd pods                            | `{}`                                   |
+| `fluentd_args`                       | Fluentd args                                                                   | `fluentd--no-supervisor -q`            |
 | `secret`                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
 | `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                        |
 | `extraVolume`                        | Extra volume                                                                   |                                        |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                               | `8`                                    |
 | `elasticsearch.scheme`               | Elasticsearch scheme setting                                                   | `http`                                 |
 | `env`                                | List of env vars that are added to the fluentd pods                            | `{}`                                   |
-| `fluentd_args`                       | Fluentd args                                                                   | `--no-supervisor -q`                   |
+| `fluentdArgs`                        | Fluentd args                                                                   | `--no-supervisor -q`                   |
 | `secret`                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
 | `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                        |
 | `extraVolume`                        | Extra volume                                                                   |                                        |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.buffer_queue_limit`   | Elasticsearch buffer queue limit                                               | `8`                                    |
 | `elasticsearch.scheme`               | Elasticsearch scheme setting                                                   | `http`                                 |
 | `env`                                | List of env vars that are added to the fluentd pods                            | `{}`                                   |
-| `fluentd_args`                       | Fluentd args                                                                   | `fluentd--no-supervisor -q`            |
+| `fluentd_args`                       | Fluentd args                                                                   | `--no-supervisor -q`                   |
 | `secret`                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
 | `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                        |
 | `extraVolume`                        | Extra volume                                                                   |                                        |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -112,12 +112,12 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: varlog
-          mountPath: {{ .Values.hostLogDir.varLog }}
+          mountPath: /var/log
         - name: varlibdockercontainers
-          mountPath: {{ .Values.hostLogDir.dockerContainers }}
+          mountPath: /var/lib/docker/containers
           readOnly: true
         - name: libsystemddir
-          mountPath: {{ .Values.hostLogDir.libSystemdDir }}
+          mountPath: /usr/lib64
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
@@ -181,14 +181,14 @@ spec:
       volumes:
       - name: varlog
         hostPath:
-          path: /var/log
+          path: {{ .Values.hostLogDir.varLog }}
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: {{ .Values.hostLogDir.dockerContainers }}
       # It is needed to copy systemd library to decompress journals
       - name: libsystemddir
         hostPath:
-          path: /usr/lib64
+          path: {{ .Values.hostLogDir.libSystemdDir }}
       - name: config-volume
         configMap:
           name: {{ include "fluentd-elasticsearch.fullname" . }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: FLUENTD_ARGS
-          value: --no-supervisor -q
+          value: {{ .Values.fluentd_args}}
         - name: OUTPUT_HOST
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: FLUENTD_ARGS
-          value: {{ .Values.fluentd_args | quote }}
+          value: {{ .Values.fluentdArgs | quote }}
         - name: OUTPUT_HOST
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: FLUENTD_ARGS
-          value: {{ .Values.fluentd_args}}
+          value: {{ .Values.fluentd_args | quote }}
         - name: OUTPUT_HOST
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -57,7 +57,7 @@ elasticsearch:
 
 # If you want to change args of fluentd process
 # by example you can add -vv to launch with trace log
-fluentd_args: "--no-supervisor -q"
+fluentdArgs: "--no-supervisor -q"
 
 # If you want to add custom environment variables, use the env dict
 # You can then reference these in your config file e.g.:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -57,7 +57,7 @@ elasticsearch:
 
 # If you want to change args of fluentd process
 # by example you can add -vv to launch with trace log
-fluentd_args:  "fluentd--no-supervisor -q"
+fluentd_args: "--no-supervisor -q"
 
 # If you want to add custom environment variables, use the env dict
 # You can then reference these in your config file e.g.:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -55,6 +55,10 @@ elasticsearch:
   buffer_queue_limit: 8
   logstash_prefix: 'logstash'
 
+# If you want to change args of fluentd process
+# by example you can add -vv to launch with trace log
+fluentd_args:  "fluentd--no-supervisor -q"
+
 # If you want to add custom environment variables, use the env dict
 # You can then reference these in your config file e.g.:
 #     user "#{ENV['OUTPUT_USER']}"


### PR DESCRIPTION
#### What this PR does / why we need it:
It allows to change the default FLUENTD_ARGS (fluentd--no-supervisor -q) to add by example -vv (fluentd--no-supervisor -q -vv) 
why I need it: I want to be able to run fluentd with full log trace 
#### Which issue this PR fixes

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
