### PR TITLE
allows to customize the mount path

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.9.2
+version: 2.10.0
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.9.1
+version: 2.9.2
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -65,8 +65,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `extraVolume`                        | Extra volume                                                                   |                                        |
 | `hostLogDir.varLog`                  | Specify where fluentd can find var log                                         | `/var/log`                             |
 | `hostLogDir.dockerContainers`        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`           |
-| `hostLogDir.varLog`                  | Specify where fluentd can find logs for user lib64                             | `/usr/lib64`                           |
-| `hostLogDir.varLog`                  | Specify where fluentd can find logs for lib Systemd                            | `/host/lib`                            |
+| `hostLogDir.libSystemdDir`           | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                           |
 | `image.repository`                   | Image                                                                          | `gcr.io/fluentd-elasticsearch/fluentd` |
 | `image.tag`                          | Image tag                                                                      | `v2.5.1`                               |
 | `image.pullPolicy`                   | Image pull policy                                                              | `IfNotPresent`                         |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -63,6 +63,10 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `secret`                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
 | `extraVolumeMounts`                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled |                                        |
 | `extraVolume`                        | Extra volume                                                                   |                                        |
+| `hostLogDir.varLog`                  | Specify where fluentd can find var log                                         | `/var/log`                             |
+| `hostLogDir.dockerContainers`        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`           |
+| `hostLogDir.varLog`                  | Specify where fluentd can find logs for user lib64                             | `/usr/lib64`                           |
+| `hostLogDir.varLog`                  | Specify where fluentd can find logs for lib Systemd                            | `/host/lib`                            |
 | `image.repository`                   | Image                                                                          | `gcr.io/fluentd-elasticsearch/fluentd` |
 | `image.tag`                          | Image tag                                                                      | `v2.5.1`                               |
 | `image.pullPolicy`                   | Image pull policy                                                              | `IfNotPresent`                         |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: FLUENTD_ARGS
-          value: --no-supervisor -q
+          value: "--no-supervisor -q"
         - name: OUTPUT_HOST
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'
@@ -120,15 +120,15 @@ spec:
 
         volumeMounts:
         - name: varlog
-          mountPath: {{ .Values.hostLogDir.varLog}}
+          mountPath: {{ .Values.hostLogDir.varLog | quote }}
         - name: varlibdockercontainers
-          mountPath: {{ .Values.hostLogDir.dockerContainers}}
+          mountPath: {{ .Values.hostLogDir.dockerContainers | quote }}
           readOnly: true
         - name: userlib64
-          mountPath: {{ .Values.hostLogDir.userLib64}}
+          mountPath: {{ .Values.hostLogDir.userLib64 | quote }}
           readOnly: true
         - name: libsystemddir
-          mountPath: {{ .Values.hostLogDir.libSystemdDir}}
+          mountPath: {{ .Values.hostLogDir.libSystemdDir | quote }}
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -112,18 +112,18 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: varlog
-          mountPath: {{ .Values.hostLogDir.varLog | quote }}
+          mountPath: {{ .Values.hostLogDir.varLog }}
         - name: varlibdockercontainers
-          mountPath: {{ .Values.hostLogDir.dockerContainers | quote }}
-          readOnly: true
-        - name: userlib64
-          mountPath: {{ .Values.hostLogDir.userLib64 | quote }}
+          mountPath: {{ .Values.hostLogDir.dockerContainers }}
           readOnly: true
         - name: libsystemddir
-          mountPath: {{ .Values.hostLogDir.libSystemdDir | quote }}
+          mountPath: {{ .Values.hostLogDir.libSystemdDir }}
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
+        - name: userlib64
+          mountPath: {{ .Values.hostLogDir.userLib64  }}
+          readOnly: true
 {{- if .Values.livenessProbe.enabled }}  #pointing to fluentd Dockerfile 
         # Liveness probe is aimed to help in situarions where fluentd
         # silently hangs for no apparent reasons until manual restart.

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -57,8 +57,6 @@ spec:
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
-        - name: FLUENTD_ARGS
-          value: "--no-supervisor -q"
         - name: OUTPUT_HOST
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -121,10 +121,7 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
-        - name: userlib64
-          mountPath: {{ .Values.hostLogDir.userLib64  }}
-          readOnly: true
-{{- if .Values.livenessProbe.enabled }}  #pointing to fluentd Dockerfile 
+{{- if .Values.livenessProbe.enabled }}  #pointing to fluentd Dockerfile
         # Liveness probe is aimed to help in situarions where fluentd
         # silently hangs for no apparent reasons until manual restart.
         # The idea of this probe is that if fluentd is not queueing or

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -110,14 +110,25 @@ spec:
               fieldPath: spec.nodeName
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+
+          - pathPrefix:
+              readOnly: false
+              - pathPrefix:
+              readOnly: true
+              - pathPrefix:
+
+
         volumeMounts:
         - name: varlog
-          mountPath: /var/log
+          mountPath: {{ .Values.hostLogDir.varLog}}
         - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
+          mountPath: {{ .Values.hostLogDir.dockerContainers}}
+          readOnly: true
+        - name: userlib64
+          mountPath: {{ .Values.hostLogDir.userLib64}}
           readOnly: true
         - name: libsystemddir
-          mountPath: /host/lib
+          mountPath: {{ .Values.hostLogDir.libSystemdDir}}
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -57,6 +57,8 @@ spec:
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        - name: FLUENTD_ARGS
+          value: --no-supervisor -q
         - name: OUTPUT_HOST
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'localhost'
@@ -108,14 +110,6 @@ spec:
               fieldPath: spec.nodeName
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-
-          - pathPrefix:
-              readOnly: false
-              - pathPrefix:
-              readOnly: true
-              - pathPrefix:
-
-
         volumeMounts:
         - name: varlog
           mountPath: {{ .Values.hostLogDir.varLog | quote }}

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -22,7 +22,7 @@ spec:
     - 'emptyDir'
     - 'hostPath'
     - 'secret'
-    allowedHostPaths:
+  allowedHostPaths:
     - pathPrefix: {{ .Values.hostLogDir.varLog}}
       readOnly: false
     - pathPrefix: {{ .Values.hostLogDir.dockerContainers}}

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -22,12 +22,14 @@ spec:
     - 'emptyDir'
     - 'hostPath'
     - 'secret'
-  allowedHostPaths:
-    - pathPrefix: /var/log
+    allowedHostPaths:
+    - pathPrefix: {{ .Values.hostLogDir.varLog}}
       readOnly: false
-    - pathPrefix: /var/lib/docker/containers
+    - pathPrefix: {{ .Values.hostLogDir.dockerContainers}}
       readOnly: true
-    - pathPrefix: /usr/lib64
+    - pathPrefix: {{ .Values.hostLogDir.userLib64}}
+      readOnly: true
+    - pathPrefix: {{ .Values.hostLogDir.libSystemdDir}}
       readOnly: true
   hostNetwork: false
   hostPID: false

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -27,8 +27,6 @@ spec:
       readOnly: false
     - pathPrefix: {{ .Values.hostLogDir.dockerContainers}}
       readOnly: true
-    - pathPrefix: {{ .Values.hostLogDir.userLib64}}
-      readOnly: true
     - pathPrefix: {{ .Values.hostLogDir.libSystemdDir}}
       readOnly: true
   hostNetwork: false

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -31,8 +31,7 @@ priorityClassName: ""
 hostLogDir:
   varLog: /var/log
   dockerContainers: /var/lib/docker/containers
-  userLib64: /usr/lib64
-  libSystemdDir: /host/lib
+  libSystemdDir: /usr/lib64
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -27,6 +27,13 @@ awsSigningSidecar:
 # Pods to make scheduling of the pending Pod possible.
 priorityClassName: ""
 
+# Specify where fluentd can find logs
+hostLogDir:
+  varLog: /var/log
+  dockerContainers: /var/lib/docker/containers
+  userLib64: /usr/lib64
+  libSystemdDir: /host/lib
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
Every K8S distrib (such CFCR the K8S opensource by Cloudfoundry) doesn't store log at the same place as your default.
This PR allows to customize where the default mountPath are located and apply changment to the podsecuritypolicy according the new mountPath. The default value are the previous defined values.

#### Which issue this PR fixes
https://github.com/kiwigrid/helm-charts/issues/96
  - fixes #96

#### Special notes for your reviewer:
@monotek 
@axdotl 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
