### PR TITLE
fix(fluentd-elasticsearch): move extraVolumeMounts part to render correct yaml

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.11.0
+version: 2.11.1
 appVersion: 2.5.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -121,7 +121,10 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
-{{- if .Values.livenessProbe.enabled }}  #pointing to fluentd Dockerfile
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      {{- if .Values.livenessProbe.enabled }}  #pointing to fluentd Dockerfile
         # Liveness probe is aimed to help in situarions where fluentd
         # silently hangs for no apparent reasons until manual restart.
         # The idea of this probe is that if fluentd is not queueing or
@@ -165,9 +168,6 @@ spec:
         - name: PORT_NUM
           value: "{{ .Values.elasticsearch.port }}"
       {{- end }}
-{{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 8 }}
-{{- end }}
         ports:
 {{- range $port := .Values.service.ports }}
           - name: {{ $port.name }}
@@ -176,7 +176,6 @@ spec:
             protocol: {{ $port.protocol }}
 {{- end }}
 {{- end }}
-
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
#### What this PR does / why we need it:

With last changes in fluentd daemonset spec in the middle of the `VolumeMounts` list `livenessProbe` was added for some reason, making use of `extraVolumeMounts` impossible. This PR should fix that.

#### Special notes for your reviewer:

Maybe some testing framework could be implemented to test those things? Smth like [bats](https://github.com/bats-core/bats-core) maybe?

#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
