### PR TITLE
Adding option to use pre-existing secrets

### DIFF
--- a/charts/gcp-serviceaccount-controller/Chart.yaml
+++ b/charts/gcp-serviceaccount-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.2.1"
 description: A Helm chart for a Kubernetes Controller to create secrets for GCP Service Accounts
 name: gcp-serviceaccount-controller
-version: 0.2.2
+version: 0.2.3
 home: https://github.com/kiwigrid/gcp-serviceaccount-controller
 sources:
 - https://github.com/kiwigrid/gcp-serviceaccount-controller

--- a/charts/gcp-serviceaccount-controller/README.md
+++ b/charts/gcp-serviceaccount-controller/README.md
@@ -39,7 +39,9 @@ The following table lists the configurable parameters of the GCP serviceaccount 
 | `image.repository`        | gcp service account controller image     | `kiwigrid/gcp-serviceaccount-controller`                                                                                                      |
 | `image.tag`               | gcp service account controller image tag | `0.2.1`                                                                                                                                       |
 | `image.pullPolicy`        | Image pull policy                        | `IfNotPresent`                                                                                                                                |
-| `gcpCredentials`          | Service account key JSON file            | Should be provided and base64 encoded when no existing secret is used, in this case a new secret will be created holding this service account |
+| `gcpCredentials`          | Service account key JSON file            | Should be provided and base64 encoded when installing the chart and no existing secret is used, in this case a new secret will be created holding this service account |
+| `existingSecret`          | Existing secret containing the service account key JSON file | null|
+| `existingSecretKey`       | The key to use within the existing secret            | "credentials.json" |
 | `disableRestrictionCheck` | Disables namespace restriction           | `false`                                                                                                                                       |
 | `resources`               | Resources                                | `{}`                                                                                                                                          |
 | `nodeSelector`            | NodeSelector                             | `{}`                                                                                                                                          |

--- a/charts/gcp-serviceaccount-controller/templates/NOTES.txt
+++ b/charts/gcp-serviceaccount-controller/templates/NOTES.txt
@@ -1,5 +1,5 @@
-{{- if (eq "" .Values.gcpCredentials)}}
-No Service Account key defined for this release. Please provide base64 encoded service account key.
+{{- if and (eq "" .Values.gcpCredentials) (not .Values.existingSecret)}}
+No Service Account key or existing secret defined for this release. Please provide either a base64 encoded service account key or an existing secret containing one.
 Bash:
   $ gcloud iam service-accounts keys create ~/key.json --iam-account SA-NAME@PROJECT-ID.iam.gserviceaccount.com
   $ base64 ~/key.json | tr -d '\n'

--- a/charts/gcp-serviceaccount-controller/templates/secret.yaml
+++ b/charts/gcp-serviceaccount-controller/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}    
 data:
   credentials.json: "{{ .Values.gcpCredentials }}"
+{{- end -}}

--- a/charts/gcp-serviceaccount-controller/templates/stateful_set.yaml
+++ b/charts/gcp-serviceaccount-controller/templates/stateful_set.yaml
@@ -43,9 +43,14 @@ spec:
           name: webhook-server
           protocol: TCP
         volumeMounts:
-        - mountPath: /var/secrets
-          name: secrets
+        - name: secrets
           readOnly: true
+        {{- if not .Values.existingSecret }}
+          mountPath: /var/secrets
+        {{- else }}
+          mountPath: /var/secrets/{{ .Values.existingSecretKey }}
+          subPath: {{ .Values.existingSecretKey }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}
@@ -65,4 +70,8 @@ spec:
       - name: secrets
         secret:
           defaultMode: 420
+          {{- if not .Values.existingSecret }}
           secretName: {{ include "gcp-serviceaccount-controller.fullname" . }}
+          {{- else }}
+          secretName: {{ .Values.existingSecret }}
+          {{- end }}

--- a/charts/gcp-serviceaccount-controller/values.yaml
+++ b/charts/gcp-serviceaccount-controller/values.yaml
@@ -7,6 +7,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 gcpCredentials: ""
+
+# Use a pre-existing secret (ignores gcpCredentials)
+# existingSecret:
+# The key to use within the existing secret
+existingSecretKey: "credentials.json"
+
 disableRestrictionCheck: false
 service:
   type: ClusterIP


### PR DESCRIPTION
Signed-off-by: Tim Jespers <t.jesp3rs@gmail.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR allows the helm operator to use a pre-existing kubernetes secret instead of supplying their base64 service account keyfile as a release value. Doing so allows the operator to keep the service account keyfile completely out of helm and/or source-control when storing their value file in a git repository.



#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
