### PR TITLE
[fluentd-elasticsearch] Fix ports block in daemonset

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 3.0.1
+version: 3.0.2
 appVersion: 2.5.2
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -160,6 +160,14 @@ spec:
                 exit 1;
               fi;
 {{- end }}
+        ports:
+{{- range $port := .Values.service.ports }}
+          - name: {{ $port.name }}
+            containerPort: {{ $port.port }}
+{{- if $port.protocol }}
+            protocol: {{ $port.protocol }}
+{{- end }}
+{{- end }}
       {{- if .Values.awsSigningSidecar.enabled }}
       - name: {{ include "fluentd-elasticsearch.fullname" . }}-aws-es-proxy
         image: {{ .Values.awsSigningSidecar.image.repository }}:{{ .Values.awsSigningSidecar.image.tag }}
@@ -170,14 +178,6 @@ spec:
         - name: PORT_NUM
           value: "{{ .Values.elasticsearch.port }}"
       {{- end }}
-        ports:
-{{- range $port := .Values.service.ports }}
-          - name: {{ $port.name }}
-            containerPort: {{ $port.port }}
-{{- if $port.protocol }}
-            protocol: {{ $port.protocol }}
-{{- end }}
-{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
Signed-off-by: Chris O'Brien <chrisob91@gmail.com>
@monotek @axdotl 
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR fixes a bug introduced in #82, which breaks service ports when `awsSigningSidecar.enabled=true` and service ports are defined.

#### Which issue this PR fixes
  - fixes #119 


#### Special notes for your reviewer:


#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
