### PR TITLE
[fluentd-elasticsearch] Changed the way services are templatized

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.1.0
+version: 4.2.0
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.2.0
+version: 4.2.1
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.2.1
+version: 4.3.0
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -94,8 +94,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `resources.requests.cpu`                     | CPU request                                                                    | `100m`                                 |
 | `resources.requests.memory`                  | Memory request                                                                 | `200Mi`                                |
 | `service`                                    | Service definition                                                             | `{}`                                   |
-| `service.type`                               | Service type (ClusterIP/NodePort)                                              | Not Set                                |
 | `service.ports`                              | List of service ports dict [{name:...}...]                                     | Not Set                                |
+| `service.ports[].type`                       | Service type (ClusterIP/NodePort)                                              | Not Set                                |
 | `service.ports[].name`                       | One of service ports name                                                      | Not Set                                |
 | `service.ports[].port`                       | Service port                                                                   | Not Set                                |
 | `service.ports[].nodePort`                   | NodePort port (when service.type is NodePort)                                  | Not Set                                |
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceAccount.create`                      | Specifies whether a service account should be created.                         | `true`                                 |
 | `serviceAccount.name`                        | Name of the service account.                                                   | `""`                                   |
 | `serviceMonitor.enabled`                     | Whether to enable Prometheus serviceMonitor                                    | `false`                                |
+| `serviceMonitor.port`                        | Define on which port the ServiceMonitor should scrape                          | `24231`                                |
 | `serviceMonitor.interval`                    | Interval at which metrics should be scraped                                    | `10s`                                  |
 | `serviceMonitor.path`                        | Path for Metrics                                                               | `/metrics`                             |
 | `serviceMonitor.labels`                      | Optional labels for serviceMonitor                                             | `{}`                                   |

--- a/charts/fluentd-elasticsearch/templates/NOTES.txt
+++ b/charts/fluentd-elasticsearch/templates/NOTES.txt
@@ -7,18 +7,20 @@ including things like IP addresses, container images, and object names will NOT 
 
 {{- if .Values.service }}
 2. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fluentd-elasticsearch.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- range $port := .Values.service.ports }}
+{{- if contains "NodePort" $port.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fluentd-elasticsearch.fullname" $ }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ $.Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" $port.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ include "fluentd-elasticsearch.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fluentd-elasticsearch.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ include "fluentd-elasticsearch.fullname" $ }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ $.Release.Namespace }} {{ include "fluentd-elasticsearch.fullname" $ }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fluentd-elasticsearch.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+{{- else if contains "ClusterIP" $port.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ $.Release.Namespace }} -l "app.kubernetes.io/name={{ include "fluentd-elasticsearch.name" $ }},app.kubernetes.io/instance={{ $.Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluentd-elasticsearch.fullname" $ }}-metrics
+  labels:
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
+    helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  type: {{ .Values.serviceMonitor.type }}
+  ports:
+    - name: metrics
+      port: {{ .Values.serviceMonitor.port }}
+      targetPort: {{ .Values.serviceMonitor.port }}
+  selector:
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -1,30 +1,31 @@
 {{- if .Values.service }}
+{{- range $port := .Values.service.ports }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fluentd-elasticsearch.fullname" . }}
+  name: {{ include "fluentd-elasticsearch.fullname" $ | trunc 50 }}-{{ $port.name | trunc 12 }}
   labels:
-    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
-    helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" $ }}
+    helm.sh/chart: {{ include "fluentd-elasticsearch.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ $port.type }}
   ports:
-  {{- range $port := .Values.service.ports }}
     - name: {{ $port.name }}
       port: {{ $port.port }}
       targetPort: {{ $port.port }}
-      {{- if $port.nodePort }}
+      {{- if and ($port.nodePort) (eq $port.type "NodePort") }}
       nodePort: {{ $port.nodePort }}
       {{- end }}
       {{- if $port.protocol }}
       protocol: {{ $port.protocol }}
       {{- end }}
-  {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "fluentd-elasticsearch.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -17,9 +17,7 @@ spec:
   endpoints:
   - interval: {{ .Values.serviceMonitor.interval }}
     honorLabels: true
-    {{- range $port := .Values.service.ports }}
-    port: {{ $port.name }}
-    {{- end }} 
+    port: metrics
     path: {{ .Values.serviceMonitor.path }}
   jobLabel: "{{ .Release.Name }}"
   selector:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -142,7 +142,7 @@ serviceMonitor:
   ##
   enabled: false
   interval: 10s
-  path: /metrics
+  port: 24231
   labels: {}
 
 prometheusRule:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR changes the way service are set up in the Chart. 
Until now, you had to define a service for the servicemonitor, but in the case several service ports were needed (e.g syslog forwarder), every svc had to be one of NodePort, ClusterIP or LoadBalancer (you don't necessary want your metrics svc to be a nodePort)
In addition, the servicemonitor would range over the list of svc port, but in the end the Kubernetes object was taking only one "port" selector.

Thats why I feature-flipped the creation of a metrics-svc, using the `serviceMonitor.enabled` boolean, and changed the `service` structure so that you can define several services of any type you want (per service).

#### Which issue this PR fixes
This issue fixes a bug of ranging over the list of service ports and displaying multiple "ports" in the serviceMonitor selector section

#### Special notes for your reviewer:
I'm not sure about the `name: {{ include "fluentd-elasticsearch.fullname" $ | trunc 50 }}-{{ $port.name | trunc 12 }}` in service definition, any idea would be welcome

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
