### PR TITLE
[hawkbit-update-server] Added Docker image pull secrets and OpenID Connect support

### DIFF
--- a/charts/hawkbit-update-server/Chart.yaml
+++ b/charts/hawkbit-update-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.3.0"
 description: A Helm chart for hawkbit update server
 name: hawkbit-update-server

--- a/charts/hawkbit-update-server/README.md
+++ b/charts/hawkbit-update-server/README.md
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the hawkbit-update-serv
 | `image.repository`                         | Docker image repo                         | `hawkbit/hawkbit-update-server`    |
 | `image.tag`                                | Docker image                              | `0.3.0M3-mysql`                    |
 | `image.pullPolicy`                         | Docker image pull policy                  | `IfNotPresent`                     |
+| `image.pullSecrets`                        | Docker image pull secrets                 | `{}`                               |
 | `service.type`                             | Service type                              | `ClusterIP`                        |
 | `service.port`                             | Service port of hawkbit-update-server UI  | `80`                               |
 | `resources`                                | Resource limits for the pod               | `{}`                               |
@@ -64,10 +65,10 @@ The following table lists the configurable parameters of the hawkbit-update-serv
 | `env.springDatasourceDb`                   | MySQL db                                  | `"hawkbit"`                        |
 | `env.springRabbitmqHost`                   | RabbitMq host                             | `"hawkbit-update-server-rabbitmq"` |
 | `env.springRabbitmqUsername`               | RabbitMq user                             | `"hawkbit"`                        |
-| `env.springRabbitmqPassword`               | RabbitMq pass                             | `"hawkbit"                         |
+| `env.springRabbitmqPassword`               | RabbitMq pass                             | `"hawkbit"`                        |
 | `env.springSecurityUserName`               | Hawkbit user                              | `"admin"`                          |
 | `env.springSecurityUserPassword`           | Hawkbit pass                              | `""`                               |
-| `extraEnv`                                 | Optional environment variables            | `{}`              
+| `extraEnv`                                 | Optional environment variables            | `{}`                               |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/charts/hawkbit-update-server/templates/deployment.yaml
+++ b/charts/hawkbit-update-server/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
     {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | trimSuffix "\n" | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/hawkbit-update-server/templates/deployment.yaml
+++ b/charts/hawkbit-update-server/templates/deployment.yaml
@@ -55,6 +55,25 @@ spec:
                 secretKeyRef:
                   name: "{{ template "hawkbit-update-server.fullname" . }}-hawkbit-pass"
                   key: "hawkbit-pass"
+            {{- if .Values.oidc.enabled }}
+            - name: "spring.security.oauth2.client.registration.oidc.client-id"
+              value: "{{ .Values.oidc.clientId }}"
+            - name: "spring.security.oauth2.client.registration.oidc.client-secret"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "hawkbit-update-server.fullname" . }}-oidc-client-secret"
+                  key: "oidc-client-secret"
+            - name: "spring.security.oauth2.client.provider.oidc.issuer-uri"
+              value: "{{ .Values.oidc.issuerUri }}"
+            - name: "spring.security.oauth2.client.provider.oidc.authorization-uri"
+              value: "{{ .Values.oidc.authorizationUri }}"
+            - name: "spring.security.oauth2.client.provider.oidc.token-uri"
+              value: "{{ .Values.oidc.tokenUri }}"
+            - name: "spring.security.oauth2.client.provider.oidc.user-info-uri"
+              value: "{{ .Values.oidc.userInfoUri }}"
+            - name: "spring.security.oauth2.client.provider.oidc.jwk-set-uri"
+              value: "{{ .Values.oidc.jwkSetUri }}"
+            {{- end }}
             {{- range $key, $value := .Values.extraEnv }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -65,13 +84,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /VAADIN/themes/hawkbit/favicon.ico
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /VAADIN/themes/hawkbit/favicon.ico
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/hawkbit-update-server/templates/deployment.yaml
+++ b/charts/hawkbit-update-server/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
+    {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/hawkbit-update-server/templates/deployment.yaml
+++ b/charts/hawkbit-update-server/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
     {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | trimSuffix "\n" | nindent 8 }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/hawkbit-update-server/templates/secrets.yaml
+++ b/charts/hawkbit-update-server/templates/secrets.yaml
@@ -40,3 +40,18 @@ data:
   {{- else }}
   hawkbit-pass: {{ printf "%s%s" .Values.security.passwordEncoder (randAlphaNum 40) | b64enc | quote }}
   {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "hawkbit-update-server.fullname" . }}-oidc-client-secret
+  labels:
+    app.kubernetes.io/name: {{ include "hawkbit-update-server.name" . }}
+    helm.sh/chart: {{ include "hawkbit-update-server.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.oidc.enabled }}
+  oidc-client-secret: {{ .Values.oidc.clientSecret | b64enc | quote }}
+  {{- end }}

--- a/charts/hawkbit-update-server/values.yaml
+++ b/charts/hawkbit-update-server/values.yaml
@@ -57,8 +57,19 @@ env:
   springSecurityUserPassword: ""
   javaOptions: "-Xms512m -Xmx512m"
 
+# OpenID Connect
+# Currently hawkBit does not support OIDC authentication managers, yet.
+# However, a pull request has been opened which introduces this feature.
+# See https://github.com/eclipse/hawkbit/pull/865.
 oidc:
   enabled: false
+  #clientId: "oidc-client-id"
+  #clientSecret: "oidc-client-secret"
+  #issuerUri: "https://oidc-provier/issuer-uri"
+  #authorizationUri: "https://oidc-provier/authorization-uri"
+  #tokenUri: "https://oidc-provier/token-uri"
+  #userInfoUri: "https://oidc-provier/user-info-uri"
+  #jwkSetUri: "https://oidc-provier/jwk-set-uri"
 
 
 # optional env vars

--- a/charts/hawkbit-update-server/values.yaml
+++ b/charts/hawkbit-update-server/values.yaml
@@ -57,6 +57,9 @@ env:
   springSecurityUserPassword: ""
   javaOptions: "-Xms512m -Xmx512m"
 
+oidc:
+  enabled: false
+
 
 # optional env vars
 extraEnv: {}

--- a/charts/hawkbit-update-server/values.yaml
+++ b/charts/hawkbit-update-server/values.yaml
@@ -63,13 +63,13 @@ env:
 # See https://github.com/eclipse/hawkbit/pull/865.
 oidc:
   enabled: false
-  #clientId: "oidc-client-id"
-  #clientSecret: "oidc-client-secret"
-  #issuerUri: "https://oidc-provier/issuer-uri"
-  #authorizationUri: "https://oidc-provier/authorization-uri"
-  #tokenUri: "https://oidc-provier/token-uri"
-  #userInfoUri: "https://oidc-provier/user-info-uri"
-  #jwkSetUri: "https://oidc-provier/jwk-set-uri"
+  # clientId: "oidc-client-id"
+  # clientSecret: "oidc-client-secret"
+  # issuerUri: "https://oidc-provier/issuer-uri"
+  # authorizationUri: "https://oidc-provier/authorization-uri"
+  # tokenUri: "https://oidc-provier/token-uri"
+  # userInfoUri: "https://oidc-provier/user-info-uri"
+  # jwkSetUri: "https://oidc-provier/jwk-set-uri"
 
 
 # optional env vars


### PR DESCRIPTION
Signed-off-by: Brandon Schmitt <Brandon.Schmitt@kiwigrid.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
It adds Docker image pull secrets used for private repositories. Moreover, it adds support for OpenID Connect.

OpenID Connect is not yet supported by the official hawBit project. However, a pull request has been opened concerning this feature. See https://github.com/eclipse/hawkbit/pull/865.
This commit covers the changes introduced by that pull request.

The configuration uses the nested value `oidc`. The feature can be enabled by setting `oidc.enabled=true`.
In that case the following, additional values must be set:
- `oidc.clientId`
- `oidc.clientSecret`
- `oidc.issuerUri`
- `oidc.authorizationUri`
- `oidc.tokenUri`
- `oidc.userInfoUri`
- `oidc.jwkSetUri`

The liveness and readiness probe has been changed accordingly to use a static resource which is always accessible without authentication. The old implementation would redirect to an OpenID Connect provider which most probably answers that redirected request with a `400 Bad Request` since the redirectUri (a private ip address) will not be valid.


#### Checklist
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
