### PR TITLE
[prometheus-thanos] Fix for misnaming the service account.

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 1.1.1
+version: 1.1.2
 home: https://github.com/improbable-eng/thanos
 sources:
 - https://github.com/improbable-eng/thanos

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccount: {{ include "prometheus-thanos.name" . }}-ruler
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-ruler
       containers:
         - name: {{ .Chart.Name }}-ruler
           imagePullPolicy: {{ .Values.ruler.image.pullPolicy }}


### PR DESCRIPTION
Instead of looking for "thanos-prometheus-thanos-ruler-token-...",
thanos ruler will now look for "prometheus-thanos-ruler-token-...".

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The wrong variable is referenced when creating the `serviceAccount` key. Using `prometheus-thanos.name` instead of `prometheus-thanos.fullname` means that the lookup service account is `thanos-prometheus-thanos-ruler-token-...` rather than `prometheus-thanos-ruler-token-...`.

This will mean that we no longer have to manually edit the statefulset to point at the correct account name.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
