### PR TITLE
[prometheus-thanos] Populated previously empty keys

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 1.1.1
+version: 1.1.2
 home: https://github.com/improbable-eng/thanos
 sources:
 - https://github.com/improbable-eng/thanos

--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 1.1.2
+version: 1.1.3
 home: https://github.com/improbable-eng/thanos
 sources:
 - https://github.com/improbable-eng/thanos

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccount: {{ include "prometheus-thanos.name" . }}-ruler
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-ruler
       containers:
         - name: {{ .Chart.Name }}-ruler
           imagePullPolicy: {{ .Values.ruler.image.pullPolicy }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -59,7 +59,7 @@ storeGateway:
     pullPolicy: IfNotPresent
   additionalLabels: {}
   additionalAnnotations: {}
-  extraEnv:
+  extraEnv: []
   # - name: GOOGLE_APPLICATION_CREDENTIALS
   #   value: /etc/gcp/secrets/credentials.json
   logLevel: info
@@ -68,7 +68,7 @@ storeGateway:
 
   objStoreType: GCS
   additionalFlags: {}
-  objStoreConfig:
+  objStoreConfig: {}
   ## GCS example
   #  bucket: demo-bucket
 
@@ -121,7 +121,7 @@ compact:
   retentionResolution1h: 10y
   consistencyDelay: 30m
   additionalFlags: {}
-  objStoreConfig:
+  objStoreConfig: {}
   ## GCS example
   #  bucket: demo-bucket
 
@@ -131,7 +131,7 @@ compact:
   #  secret_key: Need8Chars
   #  endpoint: a
   #  insecure: true
-  extraEnv:
+  extraEnv: []
   # - name: GOOGLE_APPLICATION_CREDENTIALS
   #   value: /etc/gcp/secrets/credentials.json
   resources: {}
@@ -159,7 +159,7 @@ ruler:
   clusterName:
   alertmanagerUrl: http://localhost
   evalInterval: 1m
-  objStoreConfig:
+  objStoreConfig: {}
   ## GCS example
   #  bucket: demo-bucket
 
@@ -169,7 +169,7 @@ ruler:
   #  secret_key: Need8Chars
   #  endpoint: a
   #  insecure: true
-  config:
+  config: {}
   #  groups:
   #  - name: metamonitoring
   #    rules:


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Empty keys have been populated with empty structures of their expected type, i.e. an array is [], object {}, to reduce yaml related warnings when deploying with helm. 

Helm raises a warning when a nil value is populated with a value of another type. So leaving keys just as `keyname:` results in helm perceiving that these keys have a type of `<nil>`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
