### PR TITLE
[fluentd-elasticsearch] Service port type default value - 2

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.3.0
+version: 4.3.1
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -95,7 +95,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `resources.requests.memory`                  | Memory request                                                                 | `200Mi`                                |
 | `service`                                    | Service definition                                                             | `{}`                                   |
 | `service.ports`                              | List of service ports dict [{name:...}...]                                     | Not Set                                |
-| `service.ports[].type`                       | Service type (ClusterIP/NodePort)                                              | Not Set                                |
+| `service.ports[].type`                       | Service type (ClusterIP/NodePort)                                              | `ClusterIP`                                |
 | `service.ports[].name`                       | One of service ports name                                                      | Not Set                                |
 | `service.ports[].port`                       | Service port                                                                   | Not Set                                |
 | `service.ports[].nodePort`                   | NodePort port (when service.type is NodePort)                                  | Not Set                                |

--- a/charts/fluentd-elasticsearch/templates/NOTES.txt
+++ b/charts/fluentd-elasticsearch/templates/NOTES.txt
@@ -8,16 +8,17 @@ including things like IP addresses, container images, and object names will NOT 
 {{- if .Values.service }}
 2. Get the application URL by running these commands:
 {{- range $port := .Values.service.ports }}
-{{- if contains "NodePort" $port.type }}
+{{- $service_type := $port.type | default "ClusterIP" -}}
+{{- if contains "NodePort" $service_type }}
   export NODE_PORT=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fluentd-elasticsearch.fullname" $ }})
   export NODE_IP=$(kubectl get nodes --namespace {{ $.Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" $port.type }}
+{{- else if contains "LoadBalancer" $service_type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ include "fluentd-elasticsearch.fullname" $ }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ $.Release.Namespace }} {{ include "fluentd-elasticsearch.fullname" $ }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" $port.type }}
+  echo http://$SERVICE_IP:{{ $port.port }}
+{{- else if contains "ClusterIP" $service_type }}
   export POD_NAME=$(kubectl get pods --namespace {{ $.Release.Namespace }} -l "app.kubernetes.io/name={{ include "fluentd-elasticsearch.name" $ }},app.kubernetes.io/instance={{ $.Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.service }}
-{{- range $port := .Values.service.ports }}
+{{- range $port := .Values.service.ports  }}
+{{- $service_type := $port.type | default "ClusterIP" }}
 ---
 apiVersion: v1
 kind: Service
@@ -13,12 +14,12 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
-  type: {{ $port.type }}
+  type: {{ $service_type }}
   ports:
     - name: {{ $port.name }}
       port: {{ $port.port }}
       targetPort: {{ $port.port }}
-      {{- if and ($port.nodePort) (eq $port.type "NodePort") }}
+      {{- if and ($port.nodePort) (eq $service_type "NodePort") }}
       nodePort: {{ $port.nodePort }}
       {{- end }}
       {{- if $port.protocol }}


### PR DESCRIPTION
Adds a ClusterIP as default value for each service that is created from ports map in values. It is needed because it is intuitive that ClusterIP is used most of the times and it is easier to add a type to a port if needed and not add for each port
```
  ports:
  - name: prom-metrics
    port: 24231
  - name: forwarder
    port: 24224
 -  name: some_new_port
    port: 9999
```
Instead of:
```
  ports:
  - name: prom-metrics
    port: 24231
    type: ClusterIP
  - name: forwarder
    port: 24224
    type: ClusterIP
 -  name: some_new_port
    port: 9999
```

#### Special notes for your reviewer:
Added another branch because of missing signoff, cannot resolve the old unfortunately

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
