### PR TITLE
[hawkbit-update-server] Document the OIDC values.

### DIFF
--- a/charts/hawkbit-update-server/Chart.yaml
+++ b/charts/hawkbit-update-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.0
+version: 0.6.1
 appVersion: "0.3.0"
 description: A Helm chart for hawkbit update server
 name: hawkbit-update-server

--- a/charts/hawkbit-update-server/README.md
+++ b/charts/hawkbit-update-server/README.md
@@ -68,6 +68,14 @@ The following table lists the configurable parameters of the hawkbit-update-serv
 | `env.springRabbitmqPassword`               | RabbitMq pass                             | `"hawkbit"`                        |
 | `env.springSecurityUserName`               | Hawkbit user                              | `"admin"`                          |
 | `env.springSecurityUserPassword`           | Hawkbit pass                              | `""`                               |
+| `oidc.enabled`                             | enable OpenID Connect authentication      | `false`                            |
+| `oidc.clientId`                            | OpenID Connect client ID                  | `""`                               |
+| `oidc.clientSecret`                        | OpenID Connect client secret              | `""`                               |
+| `oidc.issuerUri`                           | OpenID Connect issuer URI                 | `""`                               |
+| `oidc.authorizationUri`                    | OpenID Connect authorization URI          | `""`                               |
+| `oidc.tokenUri`                            | OpenID Connect token URI                  | `""`                               |
+| `oidc.userInfoUri`                         | OpenID Connect user info URI              | `""`                               |
+| `oidc.jwkSetUri`                           | OpenID Connect JWK set URI                | `""`                               |
 | `extraEnv`                                 | Optional environment variables            | `{}`                               |
 
 


### PR DESCRIPTION
Signed-off-by: Brandon Schmitt <Brandon.Schmitt@kiwigrid.com>

#### What this PR does / why we need it:
The PR https://github.com/kiwigrid/helm-charts/pull/132 did not document the newly introduced OpenID Connect values. This PR corrects that.

#### Checklist
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
