### PR TITLE
[fluentd-elasticsearch] Fix bug introduced in #127

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.3.1
+version: 4.3.2
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.3.0
+version: 4.3.1
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -131,9 +131,9 @@ affinity: {}
 nodeSelector: {}
 
 service: {}
-  # type: ClusterIP
   # ports:
   #   - name: "monitor-agent"
+  #     type: ClusterIP
   #     port: 24231
 
 serviceMonitor:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -142,6 +142,7 @@ serviceMonitor:
   ##
   enabled: false
   interval: 10s
+  path: /metrics
   port: 24231
   labels: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
@monotek 
#### What this PR does / why we need it:
#127 introduced a bug which breaks any configurations with the following values override:
```
serviceMonitor:
  enabled: true
```

This PR simply re-adds the `serviceMonitor.path: /metrics` default value that was (mistakenly?) removed in  #127.

#### Which issue this PR fixes



#### Special notes for your reviewer:
This is the second (or third?) time I've encountered a breaking bug since this chart has moved here from helm/charts. Maybe PR reviews/CI could be a bit more comprehensive?

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
