### PR TITLE
[fluentd-elasticsearch] make log level configurable

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.3.2
+version: 4.4.0
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.scheme`                       | Elasticsearch scheme setting                                                   | `http`                                 |
 | `elasticsearch.sslVerify`                    | Elasticsearch Auth SSL verify                                                  | `true`                                 |
 | `elasticsearch.sslVersion`                   | Elasticsearch tls version setting                                              | `TLSv1_2`                              |
+| `elasticsearch.logLevel`		       | Elasticsearch global log level							| `info`				 |
 | `env`                                        | List of env vars that are added to the fluentd pods                            | `{}`                                   |
 | `fluentdArgs`                                | Fluentd args                                                                   | `--no-supervisor -q`                   |
 | `secret`                                     | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -470,7 +470,7 @@ data:
     <match **>
       @id elasticsearch
       @type elasticsearch
-      @log_level info
+      @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key true
       type_name _doc
       host "#{ENV['OUTPUT_HOST']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -93,6 +93,8 @@ spec:
           value: {{ .Values.elasticsearch.bufferChunkLimit | quote }}
         - name: OUTPUT_BUFFER_QUEUE_LIMIT
           value: {{ .Values.elasticsearch.bufferQueueLimit | quote }}
+        - name: OUTPUT_LOG_LEVEL
+          value: {{ .Values.elasticsearch.logLevel | quote }}
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -57,6 +57,7 @@ elasticsearch:
   scheme: "http"
   sslVerify: true
   sslVersion: "TLSv1_2"
+  logLevel: "info"
 
 # If you want to change args of fluentd process
 # by example you can add -vv to launch with trace log


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR makes global log level configurable from values.yaml under elasticsearch section.

#### Special notes for your reviewer:
In configmaps.yaml, @log_level now takes specified values from OUTPUT_LOG_LEVEL environment variable

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
