### PR TITLE
[fluentd-elasticsearch] remove deprecated kubernetes.io/cluster-service label

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.6.0
+version: 4.6.1
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -8,7 +8,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:

--- a/charts/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -8,7 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:

--- a/charts/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
 - kind: ServiceAccount

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
 - kind: ServiceAccount

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -8,7 +8,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
 - kind: ServiceAccount

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 data:
 {{- if .Values.configMaps.useDefaults.systemConf }}

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -7,7 +7,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 data:
 {{- if .Values.configMaps.useDefaults.systemConf }}

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -7,7 +7,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 data:
 {{- if .Values.configMaps.useDefaults.systemConf }}

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -7,7 +7,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 {{- if .Values.annotations }}
   annotations:
@@ -27,7 +29,9 @@ spec:
         helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
         kubernetes.io/cluster-service: "true"
+        {{- end }}
       annotations:
         {{- if semverCompare "< 1.13" .Capabilities.KubeVersion.GitVersion }}
         # This annotation ensures that fluentd does not get evicted if the node

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 {{- if .Values.annotations }}
   annotations:
@@ -26,6 +27,7 @@ spec:
         helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        kubernetes.io/cluster-service: "true"
       annotations:
         {{- if semverCompare "< 1.13" .Capabilities.KubeVersion.GitVersion }}
         # This annotation ensures that fluentd does not get evicted if the node

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
@@ -29,7 +29,7 @@ spec:
         helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
         kubernetes.io/cluster-service: "true"
         {{- end }}
       annotations:

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -7,7 +7,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 {{- if .Values.annotations }}
   annotations:
@@ -27,7 +26,6 @@ spec:
         helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        kubernetes.io/cluster-service: "true"
       annotations:
         {{- if semverCompare "< 1.13" .Capabilities.KubeVersion.GitVersion }}
         # This annotation ensures that fluentd does not get evicted if the node

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: {{ .Values.serviceMonitor.type }}

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -9,7 +9,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: {{ .Values.serviceMonitor.type }}

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -9,7 +9,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: {{ .Values.serviceMonitor.type }}

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -8,7 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   annotations:
 {{- if .Values.podSecurityPolicy.annotations }}

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
   annotations:
 {{- if .Values.podSecurityPolicy.annotations }}

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -8,7 +8,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
   annotations:
 {{- if .Values.podSecurityPolicy.annotations }}

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -8,7 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     {{- if .Values.prometheusRule.labels }}
     {{- toYaml .Values.prometheusRule.labels | nindent 4 }}

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -8,7 +8,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
     {{- if .Values.prometheusRule.labels }}
     {{- toYaml .Values.prometheusRule.labels | nindent 4 }}

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     {{- if .Values.prometheusRule.labels }}
     {{- toYaml .Values.prometheusRule.labels | nindent 4 }}

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups: ['extensions']

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -8,7 +8,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups: ['extensions']

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -8,7 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups: ['extensions']

--- a/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   kind: Role

--- a/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -9,7 +9,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   kind: Role

--- a/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   kind: Role

--- a/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -8,5 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 {{- end -}}

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -8,6 +8,5 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 {{- end -}}

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 {{- end -}}

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: {{ $service_type }}

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -11,7 +11,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: {{ $service_type }}

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   type: {{ $service_type }}

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     {{- if .Values.serviceMonitor.labels }}
     {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -8,7 +8,6 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     {{- if .Values.serviceMonitor.labels }}
     {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -8,7 +8,9 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if semverCompare "< 1.12" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
+    {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
     {{- if .Values.serviceMonitor.labels }}
     {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fix exception `unexpected error error_class=NoMethodError error="undefined method []' for nil:NilClass"` on `fluentd` container caused by the DaemonSet that has this flag.

#### Which issue this PR fixes
  - fixes kubernetes/kubernetes#51376
  - relates to fluent/fluentd-kubernetes-daemonset#335

#### Special notes for your reviewer:
- fix has already been merged in the fluentd DaemonSet repo fluent/fluentd-kubernetes-daemonset#335

This flag was obsoleted as per kubernetes/kubernetes#51376 and will
trigger an exception on `fluentd` container:

```sh
2019-07-23 17:29:29 +0000 [error]: unexpected error error_class=NoMethodError error="undefined method `[]' for nil:NilClass"
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/out_elasticsearch.rb:335:in `detect_es_major_version'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/out_elasticsearch.rb:245:in `block in configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/elasticsearch_index_template.rb:35:in `retry_operate'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/out_elasticsearch.rb:244:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/plugin.rb:164:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:130:in `add_match'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:72:in `block in configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:64:in `each'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:64:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/root_agent.rb:150:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/engine.rb:131:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/engine.rb:96:in `run_configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:801:in `run_configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:548:in `block in run_worker'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:730:in `main_process'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:544:in `run_worker'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/command/fluentd.rb:316:in `<top (required)>'
  2019-07-23 17:29:29 +0000 [error]: /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2019-07-23 17:29:29 +0000 [error]: /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/bin/fluentd:8:in `<top (required)>'
  2019-07-23 17:29:29 +0000 [error]: /usr/local/bin/fluentd:22:in `load'
  2019-07-23 17:29:29 +0000 [error]: /usr/local/bin/fluentd:22:in `<main>'
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)