### PR TITLE
[fluentd-elasticsearch] fix service template rendering

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.8.0
+version: 4.8.1
 appVersion: 2.6.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "> 1.6" $.Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
Issue triggered when defining any service port as .Capabilities cannot be evaluated inside a range loop.

When attempted the following error is shown:
> rpc error: code = Unknown desc = render error in "fluentd-elasticsearch/templates/service.yaml": template: fluentd-elasticsearch/templates/service.yaml:14:46: executing "fluentd-elasticsearch/templates/service.yaml" at <.Capabilities.KubeVersion.GitVersion>: nil pointer evaluating interface {}.KubeVersion