### PR TITLE
[prometheus-thanos] add thanos ruler service

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 1.2.1
+version: 1.3.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -99,6 +99,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `service.storeGateway.type` | Service type for the store gateway | `ClusterIP` |
 | `service.storeGateway.http.port` | Service http port for the store gateway | `9090` |
 | `service.storeGateway.grpc.port` | Service grpc port for the store gateway | `10901` |
+| `service.ruler.type` | Service type for ruler | `ClusterIP` |
+| `service.ruler.http.port` | Service http port for ruler | `9090` |
+| `service.ruler.grpc.port` | Service grpc port for ruler | `10901` |
 | `querier.logLevel` | querier log level | `info` |
 | `querier.stores` | list of stores [see](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md) | `[]` |
 | `querier.additionalFlags` | additional command line flags | `{}` |

--- a/charts/prometheus-thanos/templates/ruler-service.yaml
+++ b/charts/prometheus-thanos/templates/ruler-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-ruler
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-ruler
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.ruler.type }}
+  ports:
+    - port: {{ .Values.service.ruler.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.ruler.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-ruler
+    app.kubernetes.io/instance: {{ .Release.Name }}
+

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -18,6 +18,12 @@ service:
       port: 9090
     grpc:
       port: 10901
+  ruler:
+    type: ClusterIP
+    http:
+      port: 9090
+    grpc:
+      port: 10901
 
 querier:
   replicaCount: 1


### PR DESCRIPTION
Signed-off-by: Rico Pahlisch <pahli88@googlemail.com>

#### What this PR does / why we need it:


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #159
  - add service for thanso ruler

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
