### PR TITLE
removed `^` from the format

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.8.4
+version: 4.8.5
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -214,7 +214,7 @@ data:
     <source>
       @id docker.log
       @type tail
-      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      format /time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
       path /var/log/docker.log
       pos_file /var/log/docker.log.pos
       tag docker


### PR DESCRIPTION
Getting so many errors due to the messages below.

```
2019-08-21T19:14:05Z docker time="2019-08-21T19:14:05.602349500Z" level=debug msg="Calling GET /v1.38/containers/json?all=1&filters=%7B%22label%22%3A%7B%22io.kubernetes.docker.type%3Dcontainer%22%3Atrue%7D%7D&limit=0"
```

In order to fix it, removed the leading `^` from the format.

You may test it in here https://regex101.com/r/MkIADf/1