### PR TITLE
[prometheus-thanos] Fix compact volume mounts manifest indentation

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -65,7 +65,7 @@ spec:
             - mountPath: /data
               name: storage-volume
           {{- with .Values.compact.volumeMounts }}
-            {{- toYaml . | nindent 14 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.compact.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Signed-off-by: Basilio Vera <basilio.vera@softonic.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

After the migration of the compact component to a statefulset instead of a deployment there's a bug when using `volumenMounts` values.
The right indentation is now 12 instead of 14.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
