### PR TITLE
[prometheus-pingdom-exporter] Add optional pod annotations

### DIFF
--- a/charts/prometheus-pingdom-exporter/Chart.yaml
+++ b/charts/prometheus-pingdom-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-pingdom-exporter
-version: 2.0.0
+version: 2.1.0
 appVersion: 20180821-1
 home: https://github.com/giantswarm/prometheus-pingdom-exporter
 description: A Helm chart for Prometheus Pingdom Exporter

--- a/charts/prometheus-pingdom-exporter/README.md
+++ b/charts/prometheus-pingdom-exporter/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the prometheus-pingdom-
 | `pingdom.appId`        | Application ID, can be created on the pingdom website | `alsototallysecret`                      |
 | `pingdom.accountEmail` | Account-E-Mail of the Account owner                   | `somebodyorelse@invalid`                 |
 | `pingdom.wait`         | time (in seconds) between accessing the Pingdom  API  | `10`                                     |
+| `pod.annotations`      | Pod annotations                                       | `{}`                                     |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/prometheus-pingdom-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pingdom-exporter/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      {{- if .Values.pod.annotations }}
+      annotations:
+        {{- toYaml .Values.pod.annotations | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "prometheus-pingdom-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/prometheus-pingdom-exporter/values.yaml
+++ b/charts/prometheus-pingdom-exporter/values.yaml
@@ -50,3 +50,8 @@ pingdom:
   accountEmail: somebodyorelse@invalid
   # time (in seconds) between accessing the Pingdom  API
   wait: 10
+
+pod:
+  annotations: {}
+    # key: "true"
+  # example: "false"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds optional annotations to the pingdom exporter pod. We need this in order to migrate the sensitive pingdom credentials into [Vault](https://www.vaultproject.io/).

We use a mutating webhook to grab secrets from Vault and push them into Kubernetes secrets, annotations on the pod are necessary to tell the init container where to find Vault, role to use, etc. e.g.

```
vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
vault.security.banzaicloud.io/vault-role: "default"
```

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist

- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
