### PR TITLE
[prometheus-pingdom-exporter] Add optional annotations to secret

### DIFF
--- a/charts/prometheus-pingdom-exporter/Chart.yaml
+++ b/charts/prometheus-pingdom-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-pingdom-exporter
-version: 2.1.0
+version: 2.2.0
 appVersion: 20180821-1
 home: https://github.com/giantswarm/prometheus-pingdom-exporter
 description: A Helm chart for Prometheus Pingdom Exporter

--- a/charts/prometheus-pingdom-exporter/README.md
+++ b/charts/prometheus-pingdom-exporter/README.md
@@ -37,6 +37,7 @@ The following table lists the configurable parameters of the prometheus-pingdom-
 | `image.repository`     | Image                                                 | `camptocamp/prometheus-pingdom-exporter` |
 | `image.tag`            | Image tag                                             | `20180821-1`                             |
 | `image.pullPolicy`     | Image pull policy                                     | `IfNotPresent`                           |
+| `secret.annotations`   | Secret annotations                                    | `{}`                                     |
 | `service.type`         | Service type                                          | `ClusterIP`                              |
 | `service.port`         | Service port of Graphite UI                           | `9100`                                   |
 | `service.annotations`  | Service annotations                                   | `{}`                                     |

--- a/charts/prometheus-pingdom-exporter/templates/secret.yaml
+++ b/charts/prometheus-pingdom-exporter/templates/secret.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "prometheus-pingdom-exporter.name" . }}
+  {{- if .Values.secret.annotations }}
+  annotations:
+    {{- toYaml .Values.secret.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-pingdom-exporter.name" . }}
     helm.sh/chart: {{ include "prometheus-pingdom-exporter.name" . }}

--- a/charts/prometheus-pingdom-exporter/values.yaml
+++ b/charts/prometheus-pingdom-exporter/values.yaml
@@ -54,4 +54,9 @@ pingdom:
 pod:
   annotations: {}
     # key: "true"
-  # example: "false"
+    # example: "false"
+
+secret:
+  annotations: {}
+    # key: "true"
+    # example: "false"


### PR DESCRIPTION
#### What this PR does / why we need it:

Similar to https://github.com/kiwigrid/helm-charts/pull/186, this PR adds the ability to assign annotations to the secret.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
