### PR TITLE
[fluentd-elasticsearch] - Fixes for mounting host paths and livenessProbe

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.9.2
+version: 4.9.3
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.9.1
+version: 4.9.2
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -84,6 +84,9 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `image.pullPolicy`                           | Image pull policy                                                              | `IfNotPresent`                         |
 | `image.pullSecrets`                          | Image pull secrets                                                             | ``                                     |
 | `livenessProbe.enabled`                      | Whether to enable livenessProbe                                                | `true`                                 |
+| `livenessProbe.initialDelaySeconds`          | livenessProbe initial delay seconds                                            | `600`                                  |
+| `livenessProbe.periodSeconds`                | livenessProbe period seconds                                                   | `60`                                   |
+| `livenessProbe.command`                      | livenessProbe command                                                          | `Set to a Linux compatible command`    |
 | `nodeSelector`                               | Optional daemonset nodeSelector                                                | `{}`                                   |
 | `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                             | `{}`                                   |
 | `podSecurityPolicy.enabled`                  | Specify if a pod security policy must be created                               | `false`                                |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -133,12 +133,12 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: varlog
-          mountPath: /var/log
+          mountPath: {{ .Values.hostLogDir.varLog }}
         - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
+          mountPath: {{ .Values.hostLogDir.dockerContainers }}
           readOnly: true
         - name: libsystemddir
-          mountPath: /usr/lib64
+          mountPath: {{ .Values.hostLogDir.libSystemdDir }}
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
@@ -154,30 +154,11 @@ spec:
         # logs fluentd collects, consider changing the threshold or turning
         # liveness probe off completely.
         livenessProbe:
-          initialDelaySeconds: 600
-          periodSeconds: 60
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           exec:
             command:
-            - '/bin/sh'
-            - '-c'
-            - >
-              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
-              STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
-              if [ ! -e /var/log/fluentd-buffers ];
-              then
-                exit 1;
-              fi;
-              touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
-              if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ];
-              then
-                rm -rf /var/log/fluentd-buffers;
-                exit 1;
-              fi;
-              touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
-              if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ];
-              then
-                exit 1;
-              fi;
+{{ toYaml .Values.livenessProbe.command | indent 12 }}
 {{- end }}
         ports:
 {{- range $port := .Values.service.ports }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -112,6 +112,29 @@ podSecurityPolicy:
 
 livenessProbe:
   enabled: true
+  initialDelaySeconds: 600
+  periodSeconds: 60
+  command:
+  - '/bin/sh'
+  - '-c'
+  - >
+    LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+    STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
+    if [ ! -e /var/log/fluentd-buffers ];
+    then
+      exit 1;
+    fi;
+    touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
+    if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ];
+    then
+      rm -rf /var/log/fluentd-buffers;
+      exit 1;
+    fi;
+    touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
+    if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ];
+    then
+      exit 1;
+    fi;
 
 annotations: {}
 


### PR DESCRIPTION
* Align host paths with mount paths
* Add capability to customise livenessProbe
* Bump chart version

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR reverts a change that was made in PR #101 to allow the paths that are mounted from the host to be aligned with the mount path we specify on the container. Previously the mount paths were hardcoded which makes it less flexible in situations where custom paths are needed (e.g. Docker on Windows).

As part of this PR I also added the ability to customise the liveness probe in order to be able to execute a custom command as this might also be needed in some cases, again thinking about Windows containers here.

#### Which issue this PR fixes
  - fixes #190 


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
