### PR TITLE
[fluentd-elasticsearch] Fix FluentdRecordsCountsHigh prometheus metric

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.9.1
+version: 4.9.2
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -58,7 +58,7 @@ spec:
         description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
 
     - alert: FluentdRecordsCountsHigh
-      expr: sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[5m])) BY (instance) >  (3 * sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[15m])) BY (instance))
+      expr: sum(rate(fluentd_output_status_emit_records{job="{{ .Release.Name }}"}[5m])) BY (instance) >  (3 * sum(rate(fluentd_output_status_emit_records{job="{{ .Release.Name }}"}[15m])) BY (instance))
       for: 1m
       labels:
         service: fluentd


### PR DESCRIPTION
Signed-off-by: Thomas FREYSS <thomas.freyss@gmail.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This issue fixes the FluentdRecordsCountsHigh prometheus alerting rule for the fluentd-elasticsearch chart, replacing a non existing metric with the appropriate one.
You can find the original issue in the fluent repo here: https://github.com/fluent/fluent-plugin-prometheus/issues/110

#### Which issue this PR fixes


#### Special notes for your reviewer:


#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
