### PR TITLE
[prometheus-thanos] Add objStoreConfigFile value

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.2.1
+version: 2.2.2
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -136,9 +136,10 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.logLevel` | store gateway log level | `info` |
 | `storeGateway.indexCacheSize` | index cache size | `500MB` |
 | `storeGateway.chunkPoolSize` | chunk pool size | `500MB` |
-| `storeGateway.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
 | `storeGateway.additionalFlags` | additional command line flags | `{}` |
-| `storeGateway.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `storeGateway.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
+| `storeGateway.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `storeGateway.objStoreConfigFile` | path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
 | `storeGateway.livenessProbe.initialDelaySeconds` | liveness probe initialDelaySeconds | `30` |
 | `storeGateway.livenessProbe.periodSeconds` | liveness probe periodSeconds | `10` |
 | `storeGateway.livenessProbe.successThreshold` | liveness probe successThreshold | `1` |
@@ -165,9 +166,10 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.retentionResolution5m` | retention for 5m buckets | `120d` |
 | `compact.retentionResolution1h` | retention for 1h buckets | `10y` |
 | `compact.consistencyDelay` | consistency delay | `30m` |
-| `compact.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
 | `compact.additionalFlags` | additional command line flags | `{}` |
-| `compact.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `compact.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `compact.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `compact.objStoreConfigFile` | path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
 | `compact.resources` | Resources | `{}` |
 | `compact.nodeSelector` | NodeSelector | `{}` |
 | `compact.tolerations` | Tolerations | `[]` |
@@ -186,9 +188,10 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.alertmanagerUrl` | ruler alert manager url | `http://localhost` |
 | `ruler.clusterName` | ruler cluster name | `nil` |
 | `ruler.queries` | ruler quieries endpoints | `[]` |
-| `ruler.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
 | `ruler.additionalFlags` | additional command line flags | `{}` |
-| `ruler.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `ruler.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `ruler.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `ruler.objStoreConfigFile` | path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
 | `ruler.config` | default ruler config | `nil` |
 | `ruler.resources` | Resources | `{}` |
 | `ruler.nodeSelector` | NodeSelector | `{}` |

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -51,6 +51,8 @@ spec:
             --objstore.config=type: {{ .Values.compact.objStoreType }}
             config:
             {{- toYaml .Values.compact.objStoreConfig | nindent 14 }}
+          {{ else if .Values.compact.objStoreConfigFile }}
+          - --objstore.config-file={{ .Values.compact.objStoreConfigFile }}
           {{- end }}
           - --wait
           ports:

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -55,6 +55,8 @@ spec:
             --objstore.config=type: {{ .Values.ruler.objStoreType }}
             config:
             {{- toYaml .Values.ruler.objStoreConfig | nindent 14 }}
+          {{ else if .Values.ruler.objStoreConfigFile }}
+          - --objstore.config-file={{ .Values.ruler.objStoreConfigFile }}
           {{- end }}
           {{- range $key, $value := .Values.ruler.additionalFlags }}
           - --{{ $key }}{{if $value }}={{ $value }}{{end}}

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
@@ -51,6 +51,8 @@ spec:
             --objstore.config=type: {{ .Values.storeGateway.objStoreType }} 
             config:
             {{- toYaml .Values.storeGateway.objStoreConfig | nindent 14 }}
+          {{ else if .Values.storeGateway.objStoreConfigFile }}
+          - --objstore.config-file={{ .Values.storeGateway.objStoreConfigFile }}
           {{- end }}
           ports:
             - name: http

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -75,7 +75,7 @@ storeGateway:
   indexCacheSize: 500MB
   chunkPoolSize: 500MB
 
-  objStoreType: GCS
+  objStoreType: GCS  # WARNING: this is default to null in other sections
   additionalFlags: {}
   objStoreConfig: {}
   ## GCS example
@@ -87,6 +87,8 @@ storeGateway:
   #  secret_key: Need8Chars
   #  endpoint: a
   #  insecure: true
+  objStoreConfigFile: null
+
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -127,6 +129,8 @@ compact:
   retentionResolution1h: 10y
   consistencyDelay: 30m
   additionalFlags: {}
+
+  objStoreType: null
   objStoreConfig: {}
   ## GCS example
   #  bucket: demo-bucket
@@ -137,6 +141,8 @@ compact:
   #  secret_key: Need8Chars
   #  endpoint: a
   #  insecure: true
+  objStoreConfigFile: null
+
   extraEnv: []
   # - name: GOOGLE_APPLICATION_CREDENTIALS
   #   value: /etc/gcp/secrets/credentials.json
@@ -180,6 +186,8 @@ ruler:
   alertmanagerUrl: http://localhost
   evalInterval: 1m
   ruleFile: /etc/thanos-ruler/**/*-rules.yaml
+
+  objStoreType: null
   objStoreConfig: {}
   ## GCS example
   #  bucket: demo-bucket
@@ -190,6 +198,8 @@ ruler:
   #  secret_key: Need8Chars
   #  endpoint: a
   #  insecure: true
+  objStoreConfigFile: null
+
   config: {}
   #  groups:
   #  - name: metamonitoring


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `objStoreConfigFile` value to `prometheus-thanos` chart for store, ruler, and compactor.

#### Which issue this PR fixes

fixes #164 


#### Special notes for your reviewer:
The default for `objStoreType` isn't consistent across the three components. I have left this as it is but might be a gotcha when using these values. I have documented it in the README and a warning in the `values.yaml`.

Changing this default would break values for those that rely on this behaviour. Which is why I didn't want to do this as part of a patch release.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
