### PR TITLE
[prometheus-thanos] - Add bucket web interface deployment and service

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.2.4
+version: 2.3.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -83,6 +83,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.resources` | Resources | `{}` |
 | `bucketWebInterface.tolerations` | Tolerations | `[]` |
 | `bucketWebInterface.updateStrategy` | Deployment update strategy | `type: RollingUpdate` |
+| `bucketWebInterface.volumeMounts` | Additional volume mounts | `nil` |
+| `bucketWebInterface.volumes` |Additional volumes | `nil` |
 | `compact.enabled` | Controls whether compact related resources should be created | `true` |
 | `compact.additionalAnnotations` | Additional annotations on compactor pod| `{}` |
 | `compact.additionalFlags` | Additional command line flags | `{}` |

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -65,6 +65,24 @@ The following table lists the configurable parameters of the prometheus-thanos c
 
 | Parameter                                  | Description                               | Default                            |
 | ------------------------------------------ | ----------------------------------------- | ---------------------------------- |
+| `bucketWebInterface.enabled` | Controls whether bucket web interface related resources should be created | `false` |
+| `bucketWebInterface.additionalAnnotations` | Additional annotations on bucket web interface pods| `{}` |
+| `bucketWebInterface.additionalFlags` | Additional command line flags | `{}` |
+| `bucketWebInterface.additionalLabels` | Additional labels on bucket web interface pods| `{}` |
+| `bucketWebInterface.affinity` | Affinity | `{}` |
+| `bucketWebInterface.extraEnv` | Extra env vars | `nil` |
+| `bucketWebInterface.image.repository` | Docker image repo for bucket web interface | `quay.io/thanos/thanos` |
+| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.7.0` |
+| `bucketWebInterface.image.pullPolicy` | Docker image pull policy for bucket web interface| `IfNotPresent` |
+| `bucketWebInterface.logLevel` | Bucket web interface log level | `info` |
+| `bucketWebInterface.nodeSelector` | NodeSelector | `{}` |
+| `bucketWebInterface.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `bucketWebInterface.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `bucketWebInterface.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
+| `bucketWebInterface.replicaCount` | Replica count for bucket web interface | `1` |
+| `bucketWebInterface.resources` | Resources | `{}` |
+| `bucketWebInterface.tolerations` | Tolerations | `[]` |
+| `bucketWebInterface.updateStrategy` | Deployment update strategy | `type: RollingUpdate` |
 | `compact.enabled` | Controls whether compact related resources should be created | `true` |
 | `compact.additionalAnnotations` | Additional annotations on compactor pod| `{}` |
 | `compact.additionalFlags` | Additional command line flags | `{}` |
@@ -156,6 +174,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
 | `ruler.volumeMounts` | Additional volume mounts | `nil` |
 | `ruler.volumes` | Additional volumes | `nil` |
+| `service.bucketWebInterface.type` | Service type for the bucket web interface | `ClusterIP` |
+| `service.bucketWebInterface.http.port` | Service http port for the bucket web interface  | `9090` |
 | `service.querier.type` | Service type for the querier | `ClusterIP` |
 | `service.querier.http.port` | Service http port for the querier  | `9090` |
 | `service.querier.grpc.port` | Service grpc port for the querier  | `10901` |

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -63,6 +63,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.bucketWebInterface.resources | nindent 12 }}
+          {{- with .Values.bucketWebInterface.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
       {{- with .Values.bucketWebInterface.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -73,6 +77,10 @@ spec:
     {{- end }}
     {{- with .Values.bucketWebInterface.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.bucketWebInterface.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -1,73 +1,77 @@
-{{- if .Values.bucketweb.enabled -}}
+{{- if .Values.bucketWebInterface.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "prometheus-thanos.fullname" . }}-bucketweb
+  name: {{ include "prometheus-thanos.fullname" . }}-bucket-web-interface
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.bucketweb.replicaCount }}
+  replicas: {{ .Values.bucketWebInterface.replicaCount }}
   strategy:
-  {{- with .Values.bucketweb.updateStrategy }}
+  {{- with .Values.bucketWebInterface.updateStrategy }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+      app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+        app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
         app.kubernetes.io/instance: {{ .Release.Name }}
         prometheus-thanos-peer: "true"
-        {{- with .Values.bucketweb.additionalLabels }}
+        {{- with .Values.bucketWebInterface.additionalLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    {{- if .Values.bucketweb.additionalAnnotations }}
+    {{- if .Values.bucketWebInterface.additionalAnnotations }}
       annotations:
-        {{- with .Values.bucketweb.additionalAnnotations }}
+        {{- with .Values.bucketWebInterface.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}-bucketweb
-          imagePullPolicy: {{ .Values.bucketweb.image.pullPolicy }}
-          image: "{{ .Values.bucketweb.image.repository }}:{{ .Values.bucketweb.image.tag }}"
+        - name: {{ .Chart.Name }}-bucket-web-interface
+          imagePullPolicy: {{ .Values.bucketWebInterface.image.pullPolicy }}
+          image: "{{ .Values.bucketWebInterface.image.repository }}:{{ .Values.bucketWebInterface.image.tag }}"
           args:
           - bucket
           - web
-          - --log.level={{ .Values.bucketweb.logLevel }}
-          {{- if .Values.bucketweb.objStoreType }}
+          - --log.level={{ .Values.bucketWebInterface.logLevel }}
+          {{- if .Values.bucketWebInterface.objStoreType }}
           - |
-            --objstore.config=type: {{ .Values.bucketweb.objStoreType }}
+            --objstore.config=type: {{ .Values.bucketWebInterface.objStoreType }}
             config:
-            {{- toYaml .Values.bucketweb.objStoreConfig | nindent 14 }}
-          {{ else if .Values.bucketweb.objStoreConfigFile }}
-          - --objstore.config-file={{ .Values.bucketweb.objStoreConfigFile }}
+            {{- toYaml .Values.bucketWebInterface.objStoreConfig | nindent 14 }}
+          {{ else if .Values.bucketWebInterface.objStoreConfigFile }}
+          - --objstore.config-file={{ .Values.bucketWebInterface.objStoreConfigFile }}
           {{- end }}
-          {{- range $key, $value := .Values.bucketweb.additionalFlags }}
+          {{- range $key, $value := .Values.bucketWebInterface.additionalFlags }}
           - --{{ $key }}{{if $value }}={{ $value }}{{end}}
           {{- end }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- if .Values.bucketWebInterface.extraEnv }}
+          env:
+            {{- toYaml .Values.bucketWebInterface.extraEnv | nindent 12 }}
+          {{- end }}
           resources:
-            {{- toYaml .Values.bucketweb.resources | nindent 12 }}
-      {{- with .Values.bucketweb.nodeSelector }}
+            {{- toYaml .Values.bucketWebInterface.resources | nindent 12 }}
+      {{- with .Values.bucketWebInterface.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.bucketweb.affinity }}
+    {{- with .Values.bucketWebInterface.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.bucketweb.tolerations }}
+    {{- with .Values.bucketWebInterface.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.bucketweb.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-bucketweb
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.bucketweb.replicaCount }}
+  strategy:
+  {{- with .Values.bucketweb.updateStrategy }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        prometheus-thanos-peer: "true"
+        {{- with .Values.bucketweb.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    {{- if .Values.bucketweb.additionalAnnotations }}
+      annotations:
+        {{- with .Values.bucketweb.additionalAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-bucketweb
+          imagePullPolicy: {{ .Values.bucketweb.image.pullPolicy }}
+          image: "{{ .Values.bucketweb.image.repository }}:{{ .Values.bucketweb.image.tag }}"
+          args:
+          - bucket
+          - web
+          - --log.level={{ .Values.bucketweb.logLevel }}
+          {{- if .Values.bucketweb.objStoreType }}
+          - |
+            --objstore.config=type: {{ .Values.bucketweb.objStoreType }}
+            config:
+            {{- toYaml .Values.bucketweb.objStoreConfig | nindent 14 }}
+          {{ else if .Values.bucketweb.objStoreConfigFile }}
+          - --objstore.config-file={{ .Values.bucketweb.objStoreConfigFile }}
+          {{- end }}
+          {{- range $key, $value := .Values.bucketweb.additionalFlags }}
+          - --{{ $key }}{{if $value }}={{ $value }}{{end}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.bucketweb.resources | nindent 12 }}
+      {{- with .Values.bucketweb.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.bucketweb.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.bucketweb.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/bucket-web-service.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.bucketweb.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-bucketweb
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.bucketweb.type }}
+  ports:
+    - port: {{ .Values.service.bucketweb.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/bucket-web-service.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-service.yaml
@@ -1,21 +1,21 @@
-{{- if .Values.bucketweb.enabled -}}
+{{- if .Values.bucketWebInterface.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "prometheus-thanos.fullname" . }}-bucketweb
+  name: {{ include "prometheus-thanos.fullname" . }}-bucket-web-interface
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.bucketweb.type }}
+  type: {{ .Values.service.bucketWebInterface.type }}
   ports:
-    - port: {{ .Values.service.bucketweb.http.port }}
+    - port: {{ .Values.service.bucketWebInterface.http.port }}
       targetPort: http
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucketweb
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -24,6 +24,10 @@ service:
       port: 9090
     grpc:
       port: 10901
+  bucketweb:
+    type: ClusterIP
+    http:
+      port: 9090
 
 querier:
   enabled: true
@@ -236,6 +240,39 @@ ruler:
     existingClaim: ""
     size: 2Gi
     storageClass: ""
+
+bucketweb:
+  enabled: false
+  additionalAnnotations: {}
+  additionalFlags: {}
+  additionalLabels: {}
+  affinity: {}
+  image:
+    repository: quay.io/thanos/thanos
+    tag: v0.7.0
+    pullPolicy: IfNotPresent
+  logLevel: info
+  objStoreType: null
+  objStoreConfig: {}
+  ## GCS example
+  #  bucket: demo-bucket
+
+  ## S3 example
+  #  bucket: demo-bucket
+  #  access_key: smth
+  #  secret_key: Need8Chars
+  #  endpoint: a
+  #  insecure: true
+  objStoreConfigFile: null
+  nodeSelector: {}
+  replicaCount: 1
+  resources: {}
+  tolerations: []
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 
 ## this is only for test support dont use this in production
 minio:

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -274,6 +274,8 @@ bucketWebInterface:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+  volumeMounts:
+  volumes:
 
 ## this is only for test support dont use this in production
 minio:

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -24,7 +24,7 @@ service:
       port: 9090
     grpc:
       port: 10901
-  bucketweb:
+  bucketWebInterface:
     type: ClusterIP
     http:
       port: 9090
@@ -241,12 +241,13 @@ ruler:
     size: 2Gi
     storageClass: ""
 
-bucketweb:
+bucketWebInterface:
   enabled: false
   additionalAnnotations: {}
   additionalFlags: {}
   additionalLabels: {}
   affinity: {}
+  extraEnv: []
   image:
     repository: quay.io/thanos/thanos
     tag: v0.7.0


### PR DESCRIPTION
Adds the ability to deploy a deployment and service for the bucket web interface. 

Signed-off-by: GuyTempleton <guy.templeton@skyscanner.net>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds the ability to deploy a new deployment and service for the Thanos Bucket Web Interface. This can be useful for administrators of a Thanos install to verify compaction/downsampling is working as expected.

![Thanos_long_term_storage_Prometheus_solution](https://user-images.githubusercontent.com/6452486/66908923-cd36ce80-f003-11e9-840c-1dfc06d3920f.png)

I've broken with the behaviour of all the other components here and set this to default to `enabled: false` as I believe it's of significantly lower value to most users than the other components.

#### Which issue this PR fixes

  - N/A


#### Special notes for your reviewer:


#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
