### PR TITLE
[prometheus-thanos] - README cleanup

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.2.3
+version: 2.2.4
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -19,16 +19,16 @@ To install the chart with the release name `prometheus-thanos`, run the followin
 helm install kiwigrid/prometheus-thanos --name prometheus-thanos --values=my-values.yaml
 ```
 
-## Using Sidcar Configmap Watcher
+## Using Sidecar Configmap Watcher
 
-To enable the sidecar you can set `ruler.sidecar.enabled` to `true`. The sidcar will then watch all configmaps and if there is a configmap with label named like `ruler.sidecar.watchLabel` the the sidecar will use the content inside the config directory of the ruler and will notify the ruler to reload the config files.
+To enable the sidecar you can set `ruler.sidecar.enabled` to `true`. The sidcar will then watch all configmaps and if there is a configmap with label named like `ruler.sidecar.watchLabel` the sidecar will use the contents inside the config directory of the ruler and will notify the ruler to reload the config files.
 
 An example configmap will look like:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
-metadata:  
+metadata:
   name: custom-config-map
   labels:
     thanos_alert_config: "1"
@@ -65,47 +65,97 @@ The following table lists the configurable parameters of the prometheus-thanos c
 
 | Parameter                                  | Description                               | Default                            |
 | ------------------------------------------ | ----------------------------------------- | ---------------------------------- |
-| `querier.enabled` | controls whether querier related resources should be created | `true` |
-| `querier.replicaCount` | replica count for querier | `1` |
-| `querier.updateStrategy` | Deployment update strategy | `type: RollingUpdate` |
-| `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
-| `querier.image.tag` | Docker image tag for querier | `v0.7.0` |
-| `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
-| `querier.additionalLabels` | Additional labels on querier pods| `{}` |
-| `querier.additionalAnnotations` | Additional annotations on querier pods| `{}` |
-| `storeGateway.enabled` | controls whether StoreGateway related resources should be created | `true` |
-| `storeGateway.replicaCount` |  for store gateway | `1` |
-| `storeGateway.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
-| `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
-| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.7.0` |
-| `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
-| `storeGateway.additionalLabels` | Additional labels on store gateway pods| `{}` |
-| `storeGateway.additionalAnnotations` | Additional annotations on store gateway pods| `{}` |
-| `compact.enabled` | controls whether compact related resources should be created | `true` |
-| `compact.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
+| `compact.enabled` | Controls whether compact related resources should be created | `true` |
+| `compact.additionalAnnotations` | Additional annotations on compactor pod| `{}` |
+| `compact.additionalFlags` | Additional command line flags | `{}` |
+| `compact.additionalLabels` | Additional labels on compactor pod| `{}` |
+| `compact.affinity` | Affinity | `{}` |
+| `compact.consistencyDelay` | Consistency delay | `30m` |
+| `compact.extraEnv` | Extra env vars | `nil` |
 | `compact.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
 | `compact.image.tag` | Docker image tag for store gateway | `v0.7.0` |
 | `compact.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
-| `compact.additionalLabels` | Additional labels on compactor pod| `{}` |
-| `compact.additionalAnnotations` | Additional annotations on compactor pod| `{}` |
-| `compact.affinity` | Affinity | `{}` |
-| `compact.tolerations` | Tolerations | `[]` |
-| `compact.volumeMounts` | Additional volume mounts | `nil` |
-| `compact.volumes` | Additional volumes | `nil` |
+| `compact.logLevel` | Store gateway log level | `info` |
+| `compact.nodeSelector` | NodeSelector | `{}` |
+| `compact.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `compact.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
+| `compact.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
 | `compact.persistentVolume.enabled` | Persistent volume enabled | `false` |
 | `compact.persistentVolume.accessModes` | Persistent volume accessModes | `[ReadWriteOnce]` |
 | `compact.persistentVolume.annotations` | Persistent volume annotations | `{}` |
 | `compact.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
 | `compact.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `compact.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `compact.resources` | Resources | `{}` |
+| `compact.retentionResolutionRaw` | Retention for raw buckets | `30d` |
+| `compact.retentionResolution5m` | Retention for 5m buckets | `120d` |
+| `compact.retentionResolution1h` | Retention for 1h buckets | `10y` |
+| `compact.tolerations` | Tolerations | `[]` |
+| `compact.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
+| `compact.volumeMounts` | Additional volume mounts | `nil` |
+| `compact.volumes` | Additional volumes | `nil` |
+| `querier.enabled` | Controls whether querier related resources should be created | `true` |
+| `querier.additionalAnnotations` | Additional annotations on querier pods| `{}` |
+| `querier.additionalFlags` | Additional command line flags | `{}` |
+| `querier.additionalLabels` | Additional labels on querier pods| `{}` |
+| `querier.affinity` | Affinity | `{}` |
+| `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
+| `querier.image.tag` | Docker image tag for querier | `v0.7.0` |
+| `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
+| `querier.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
+| `querier.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
+| `querier.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
+| `querier.livenessProbe.timeoutSeconds` | Liveness probe timeoutSeconds | `30` |
+| `querier.logLevel` | Querier log level | `info` |
+| `querier.nodeSelector` | NodeSelector | `{}` |
+| `querier.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
+| `querier.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
+| `querier.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
+| `querier.readinessProbe.timeoutSeconds` | Readiness probe timeoutSeconds | `30` |
+| `querier.replicaCount` | Replica count for querier | `1` |
+| `querier.resources` | Resources | `{}` |
+| `querier.stores` | List of stores [see](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md) | `[]` |
+| `querier.tolerations` | Tolerations | `[]` |
+| `querier.updateStrategy` | Deployment update strategy | `type: RollingUpdate` |
+| `querier.volumeMounts` | Additional volume mounts | `nil` |
+| `querier.volumes` | Additional volumes | `nil` |
 | `ruler.enabled` | controls whether ruler related resources should be created | `true` |
-| `ruler.replicaCount` |  for ruler | `1` |
-| `ruler.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
+| `ruler.additionalAnnotations` | Additional annotations on ruler pod| `{}` |
+| `ruler.additionalFlags` | Additional command line flags | `{}` |
+| `ruler.additionalLabels` | Additional labels on ruler pod| `{}` |
+| `ruler.affinity` | Affinity | `{}` |
+| `ruler.alertmanagerUrl` | Ruler alert manager url | `http://localhost` |
+| `ruler.clusterName` | Ruler cluster name | `nil` |
+| `ruler.config` | Default ruler config | `nil` |
+| `ruler.evalInterval` | Ruler evaluation interval | `1m` |
+| `ruler.extraEnv` | Extra env vars | `nil` |
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
 | `ruler.image.tag` | Docker image tag for ruler | `v0.7.0` |
 | `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
-| `ruler.additionalLabels` | Additional labels on ruler pod| `{}` |
-| `ruler.additionalAnnotations` | Additional annotations on ruler pod| `{}` |
+| `ruler.logLevel` | Ruler log level | `info` |
+| `ruler.nodeSelector` | NodeSelector | `{}` |
+| `ruler.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
+| `ruler.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `ruler.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
+| `ruler.persistentVolume.enabled` | Persistent volume enabled | `enabled` |
+| `ruler.persistentVolume.accessModes` | Persistent volume accessModes | `[ReadWriteOnce]` |
+| `ruler.persistentVolume.annotations` | Persistent volume annotations | `{}` |
+| `ruler.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
+| `ruler.persistentVolume.size` | Persistent volume size | `2Gi` |
+| `ruler.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `ruler.queries` | Ruler quieries endpoints | `[]` |
+| `ruler.replicaCount` |  Replica count for ruler | `1` |
+| `ruler.resources` | Resources | `{}` |
+| `ruler.ruleFile` | Rule files that should be used | `/etc/thanos-ruler/**/*-rules.yaml` |
+| `ruler.sidecar.image.repository` | Docker image for configmap watcher sidecar | `kiwigrid/k8s-configmap-watcher` |
+| `ruler.sidecar.image.tag` | Docker image tag for configmap watcher sidecar | `0.1.1` |
+| `ruler.sidecar.image.pullPolicy` | Pull policy for configmap watcher sidecar | `IfNotPresent` |
+| `ruler.sidecar.enabled` | Enable configmap watcher sidecar | `false` |
+| `ruler.sidecar.watchLabel` | Label for configmaps to watch | `thanos_alert_config` |
+| `ruler.tolerations` | Tolerations | `[]` |
+| `ruler.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
+| `ruler.volumeMounts` | Additional volume mounts | `nil` |
+| `ruler.volumes` | Additional volumes | `nil` |
 | `service.querier.type` | Service type for the querier | `ClusterIP` |
 | `service.querier.http.port` | Service http port for the querier  | `9090` |
 | `service.querier.grpc.port` | Service grpc port for the querier  | `10901` |
@@ -115,96 +165,42 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `service.ruler.type` | Service type for ruler | `ClusterIP` |
 | `service.ruler.http.port` | Service http port for ruler | `9090` |
 | `service.ruler.grpc.port` | Service grpc port for ruler | `10901` |
-| `querier.logLevel` | querier log level | `info` |
-| `querier.stores` | list of stores [see](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md) | `[]` |
-| `querier.additionalFlags` | additional command line flags | `{}` |
-| `querier.livenessProbe.initialDelaySeconds` | liveness probe initialDelaySeconds | `30` |
-| `querier.livenessProbe.periodSeconds` | liveness probe periodSeconds | `10` |
-| `querier.livenessProbe.successThreshold` | liveness probe successThreshold | `1` |
-| `querier.livenessProbe.timeoutSeconds` | liveness probe timeoutSeconds | `30` |
-| `querier.readinessProbe.initialDelaySeconds` | readiness probe initialDelaySeconds | `30` |
-| `querier.readinessProbe.periodSeconds` | readiness probe periodSeconds | `10` |
-| `querier.readinessProbe.successThreshold` | readiness probe successThreshold | `1` |
-| `querier.readinessProbe.timeoutSeconds` | readiness probe timeoutSeconds | `30` |
-| `querier.resources` | Resources | `{}` |
-| `querier.nodeSelector` | NodeSelector | `{}` |
-| `querier.tolerations` | Tolerations | `[]` |
-| `querier.affinity` | Affinity | `{}` |
-| `querier.volumeMounts` | additional volume mounts | `nil` |
-| `querier.volumes` | additional volumes | `nil` |
-| `storeGateway.extraEnv` | extra env vars | `nil` |
-| `storeGateway.logLevel` | store gateway log level | `info` |
-| `storeGateway.indexCacheSize` | index cache size | `500MB` |
-| `storeGateway.chunkPoolSize` | chunk pool size | `500MB` |
-| `storeGateway.additionalFlags` | additional command line flags | `{}` |
-| `storeGateway.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
-| `storeGateway.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
-| `storeGateway.objStoreConfigFile` | path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
-| `storeGateway.livenessProbe.initialDelaySeconds` | liveness probe initialDelaySeconds | `30` |
-| `storeGateway.livenessProbe.periodSeconds` | liveness probe periodSeconds | `10` |
-| `storeGateway.livenessProbe.successThreshold` | liveness probe successThreshold | `1` |
-| `storeGateway.livenessProbe.timeoutSeconds` | liveness probe timeoutSeconds | `30` |
-| `storeGateway.readinessProbe.initialDelaySeconds` | readiness probe initialDelaySeconds | `30` |
-| `storeGateway.readinessProbe.periodSeconds` | readiness probe periodSeconds | `10` |
-| `storeGateway.readinessProbe.successThreshold` | readiness probe successThreshold | `1` |
-| `storeGateway.readinessProbe.timeoutSeconds` | readiness probe timeoutSeconds | `30` |
-| `storeGateway.resources` | Resources | `{}` |
-| `storeGateway.nodeSelector` | NodeSelector | `{}` |
-| `storeGateway.tolerations` | Tolerations | `[]` |
+| `storeGateway.enabled` | Controls whether StoreGateway related resources should be created | `true` |
 | `storeGateway.affinity` | Affinity | `{}` |
-| `storeGateway.volumeMounts` | additional volume mounts | `nil` |
-| `storeGateway.volumes` | additional volumes | `nil` |
-| `storeGateway.persistentVolume.enabled` | persistent volume enabled | `enabled` |
-| `storeGateway.persistentVolume.accessModes` | persistent volume accessModes | `[ReadWriteOnce]` |
-| `storeGateway.persistentVolume.annotations` | persistent volume annotations | `{}` |
-| `storeGateway.persistentVolume.existingClaim` | persistent volume existingClaim | `` |
-| `storeGateway.persistentVolume.size` | persistent volume size | `2Gi` |
+| `storeGateway.additionalAnnotations` | Additional annotations on store gateway pods| `{}` |
+| `storeGateway.additionalFlags` | Additional command line flags | `{}` |
+| `storeGateway.additionalLabels` | Additional labels on store gateway pods| `{}` |
+| `storeGateway.chunkPoolSize` | Chunk pool size | `500MB` |
+| `storeGateway.extraEnv` | Extra env vars | `nil` |
+| `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
+| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.7.0` |
+| `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
+| `storeGateway.indexCacheSize` | Index cache size | `500MB` |
+| `storeGateway.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
+| `storeGateway.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
+| `storeGateway.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
+| `storeGateway.livenessProbe.timeoutSeconds` | Liveness probe timeoutSeconds | `30` |
+| `storeGateway.logLevel` | Store gateway log level | `info` |
+| `storeGateway.nodeSelector` | NodeSelector | `{}` |
+| `storeGateway.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `storeGateway.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
+| `storeGateway.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
+| `storeGateway.persistentVolume.enabled` | Persistent volume enabled | `enabled` |
+| `storeGateway.persistentVolume.accessModes` | Persistent volume accessModes | `[ReadWriteOnce]` |
+| `storeGateway.persistentVolume.annotations` | Persistent volume annotations | `{}` |
+| `storeGateway.persistentVolume.existingClaim` | Persistent volume existingClaim | `` |
+| `storeGateway.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `storeGateway.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
-| `compact.extraEnv` | extra env vars | `nil` |
-| `compact.logLevel` | store gateway log level | `info` |
-| `compact.retentionResolutionRaw` | retention for raw buckets | `30d` |
-| `compact.retentionResolution5m` | retention for 5m buckets | `120d` |
-| `compact.retentionResolution1h` | retention for 1h buckets | `10y` |
-| `compact.consistencyDelay` | consistency delay | `30m` |
-| `compact.additionalFlags` | additional command line flags | `{}` |
-| `compact.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
-| `compact.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
-| `compact.objStoreConfigFile` | path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
-| `compact.resources` | Resources | `{}` |
-| `compact.nodeSelector` | NodeSelector | `{}` |
-| `compact.tolerations` | Tolerations | `[]` |
-| `compact.affinity` | Affinity | `{}` |
-| `compact.volumeMounts` | additional volume mounts | `nil` |
-| `compact.volumes` | additional volumes | `nil` |
-| `ruler.sidecar.image.repository` | Docker image for configmap watcher sidecar | `kiwigrid/k8s-configmap-watcher` |
-| `ruler.sidecar.image.tag` | Docker image tag for configmap watcher sidecar | `0.1.1` |
-| `ruler.sidecar.image.pullPolicy` | pull policy for configmap watcher sidecar | `IfNotPresent` |
-| `ruler.sidecar.enabled` | enable configmap watcher sidecar | `false` |
-| `ruler.sidecar.watchLabel` | label for configmaps to watch | `thanos_alert_config` |
-| `ruler.extraEnv` | extra env vars | `nil` |
-| `ruler.logLevel` | ruler log level | `info` |
-| `ruler.evalInterval` | ruler evaluation interval | `1m` |
-| `ruler.ruleFile` | rule files that should be used | `/etc/thanos-ruler/**/*-rules.yaml` |
-| `ruler.alertmanagerUrl` | ruler alert manager url | `http://localhost` |
-| `ruler.clusterName` | ruler cluster name | `nil` |
-| `ruler.queries` | ruler quieries endpoints | `[]` |
-| `ruler.additionalFlags` | additional command line flags | `{}` |
-| `ruler.objStoreType` | object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
-| `ruler.objStoreConfig` | config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
-| `ruler.objStoreConfigFile` | path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
-| `ruler.config` | default ruler config | `nil` |
-| `ruler.resources` | Resources | `{}` |
-| `ruler.nodeSelector` | NodeSelector | `{}` |
-| `ruler.tolerations` | Tolerations | `[]` |
-| `ruler.affinity` | Affinity | `{}` |
-| `ruler.volumeMounts` | additional volume mounts | `nil` |
-| `ruler.volumes` | additional volumes | `nil` |
-| `ruler.persistentVolume.enabled` | persistent volume enabled | `enabled` |
-| `ruler.persistentVolume.accessModes` | persistent volume accessModes | `[ReadWriteOnce]` |
-| `ruler.persistentVolume.annotations` | persistent volume annotations | `{}` |
-| `ruler.persistentVolume.existingClaim` | persistent volume existingClaim | `""` |
-| `ruler.persistentVolume.size` | persistent volume size | `2Gi` |
-| `ruler.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `storeGateway.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
+| `storeGateway.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
+| `storeGateway.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
+| `storeGateway.readinessProbe.timeoutSeconds` |Readiness probe timeoutSeconds | `30` |
+| `storeGateway.replicaCount` | Replica count for store gateway | `1` |
+| `storeGateway.resources` | Resources | `{}` |
+| `storeGateway.tolerations` | Tolerations | `[]` |
+| `storeGateway.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
+| `storeGateway.volumeMounts` | Additional volume mounts | `nil` |
+| `storeGateway.volumes` |Additional volumes | `nil` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 


### PR DESCRIPTION
Signed-off-by: GuyTempleton <guy.templeton@skyscanner.net>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Tidies up the docs for the prometheus-thanos chart in a small number of ways:

* Alphabetical sorting for all supported variables

* Remove 4 duplicate compact variable listing (compact.affinity, compact.volumes, compact.volumeMounts and compact.tolerations)

* Consistent casing and naming across variable descriptions

* Minor grammatical and typo fixes

#### Which issue this PR fixes
  - N/A


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
