### PR TITLE
[fluentd-elasticsearch] make liveness probe kind configurable

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 4.9.4
+version: 5.0.0
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `livenessProbe.enabled`                      | Whether to enable livenessProbe                                                | `true`                                 |
 | `livenessProbe.initialDelaySeconds`          | livenessProbe initial delay seconds                                            | `600`                                  |
 | `livenessProbe.periodSeconds`                | livenessProbe period seconds                                                   | `60`                                   |
-| `livenessProbe.command`                      | livenessProbe command                                                          | `Set to a Linux compatible command`    |
+| `livenessProbe.kind`                         | livenessProbe kind                                                             | `Set to a Linux compatible command`    |
 | `nodeSelector`                               | Optional daemonset nodeSelector                                                | `{}`                                   |
 | `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                             | `{}`                                   |
 | `podSecurityPolicy.enabled`                  | Specify if a pod security policy must be created                               | `false`                                |
@@ -132,6 +132,8 @@ $ helm install --name my-release -f values.yaml kiwigrid/fluentd-elasticsearch
 ## Upgrading
 
 When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--force" parameter to your helm upgrade command as there have been changes to the lables which makes a normal upgrade impossible.
+
+When upgrading this chart from a version &ge; 4.9.3 to version &ge; 5.0.0, you need to rename `livenessProbe.command` parameter to `livenessProbe.kind.exec.command` (only applicable if `livenessProbe.command` parameter was used).
 
 ## AWS Elasticsearch Domains
 

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -146,19 +146,10 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
       {{- if .Values.livenessProbe.enabled }}  #pointing to fluentd Dockerfile
-        # Liveness probe is aimed to help in situarions where fluentd
-        # silently hangs for no apparent reasons until manual restart.
-        # The idea of this probe is that if fluentd is not queueing or
-        # flushing chunks for 5 minutes, something is not right. If
-        # you want to change the fluentd configuration, reducing amount of
-        # logs fluentd collects, consider changing the threshold or turning
-        # liveness probe off completely.
         livenessProbe:
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          exec:
-            command:
-{{ toYaml .Values.livenessProbe.command | indent 12 }}
+{{ toYaml .Values.livenessProbe.kind | indent 10 }}
 {{- end }}
         ports:
 {{- range $port := .Values.service.ports }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -114,27 +114,36 @@ livenessProbe:
   enabled: true
   initialDelaySeconds: 600
   periodSeconds: 60
-  command:
-  - '/bin/sh'
-  - '-c'
-  - >
-    LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
-    STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
-    if [ ! -e /var/log/fluentd-buffers ];
-    then
-      exit 1;
-    fi;
-    touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
-    if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ];
-    then
-      rm -rf /var/log/fluentd-buffers;
-      exit 1;
-    fi;
-    touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
-    if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ];
-    then
-      exit 1;
-    fi;
+  kind:
+    exec:
+      command:
+      # Liveness probe is aimed to help in situations where fluentd
+      # silently hangs for no apparent reasons until manual restart.
+      # The idea of this probe is that if fluentd is not queueing or
+      # flushing chunks for 5 minutes, something is not right. If
+      # you want to change the fluentd configuration, reducing amount of
+      # logs fluentd collects, consider changing the threshold or turning
+      # liveness probe off completely.
+      - '/bin/sh'
+      - '-c'
+      - >
+        LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+        STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
+        if [ ! -e /var/log/fluentd-buffers ];
+        then
+          exit 1;
+        fi;
+        touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
+        if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ];
+        then
+          rm -rf /var/log/fluentd-buffers;
+          exit 1;
+        fi;
+        touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
+        if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ];
+        then
+          exit 1;
+        fi;
 
 annotations: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently it's not possible to use alternative forms of liveness probes like [httpGet](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request) as it's assumed a command is always used.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
