### PR TITLE
Support arbitrary service annotation

### DIFF
--- a/charts/hawkbit-update-server/Chart.yaml
+++ b/charts/hawkbit-update-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 2.0.2
-appVersion: "0.3.0"
+version: 2.1.0
+appVersion: "0.3.0M5-mysql"
 description: A Helm chart for hawkbit update server
 name: hawkbit-update-server
 home: https://www.eclipse.org/hawkbit/
@@ -13,3 +13,5 @@ maintainers:
   email: fabian.schlegel@kiwigrid.com
 - name: monotek
   email: andre.bauer@kiwigrid.com
+- name: axdotl
+  email: axel.koehler@kiwigrid.com

--- a/charts/hawkbit-update-server/README.md
+++ b/charts/hawkbit-update-server/README.md
@@ -8,14 +8,14 @@ This chart uses hawkbit/hawkbit-update-server container to run Hawkbit update se
 
 ## Prerequisites
 
--   Has been tested on Kubernetes 1.11+
+- Has been tested on Kubernetes 1.11+
 
 ## Installing the Chart
 
 To install the chart with the release name `hawkbit-update-server`, run the following command:
 
 ```bash
-$ helm install kiwigrid/hawkbit-update-server --name hawkbit-update-server
+helm install kiwigrid/hawkbit-update-server --name hawkbit-update-server
 ```
 
 ## Uninstalling the Chart
@@ -23,7 +23,7 @@ $ helm install kiwigrid/hawkbit-update-server --name hawkbit-update-server
 To uninstall/delete the `hawkbit-update-server` deployment:
 
 ```bash
-$ helm delete hawkbit-update-server
+helm delete hawkbit-update-server
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -37,9 +37,10 @@ The following table lists the configurable parameters of the hawkbit-update-serv
 | Parameter                                  | Description                               | Default                            |
 | ------------------------------------------ | ----------------------------------------- | ---------------------------------- |
 | `image.repository`                         | Docker image repo                         | `hawkbit/hawkbit-update-server`    |
-| `image.tag`                                | Docker image                              | `0.3.0M3-mysql`                    |
+| `image.tag`                                | Docker image                              | `0.3.0M5-mysql`                    |
 | `image.pullPolicy`                         | Docker image pull policy                  | `IfNotPresent`                     |
 | `image.pullSecrets`                        | Docker image pull secrets                 | `{}`                               |
+| `service.annotations`                      | Service annotations                       | `{}`                               |
 | `service.type`                             | Service type                              | `ClusterIP`                        |
 | `service.port`                             | Service port of hawkbit-update-server UI  | `80`                               |
 | `resources`                                | Resource limits for the pod               | `{}`                               |
@@ -104,11 +105,14 @@ The following table lists the configurable parameters of the hawkbit-update-serv
 | `rabbitmq.rabbitmq.username`               | Rabbitmq username                         | `hawkbit`                          |
 | `rabbitmq.rabbitmq.password`               | Rabbitmq password                         | `hawkbit`                          |
 | `rabbitmq.rabbitmq.metrics.enabled`        | use Rabbitmq Prometheus metrics           | `true`                             |  
+| `podDisruptionBudget.enabled`              | PodDisruptionBudget enabled               | `false`                            |
+| `podDisruptionBudget.minAvailable`         | PodDisruptionBudget min. available pods   | `1`                                |
+| `updateStrategy`                           | Deployment strategy to replace old pods   | `type: Recreate`                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```bash
-$ helm install --name hawkbit-update-server --set ingress.enabled=false kiwigrid/hawkbit-update-server
+helm install --name hawkbit-update-server --set ingress.enabled=false kiwigrid/hawkbit-update-server
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.

--- a/charts/hawkbit-update-server/templates/deployment.yaml
+++ b/charts/hawkbit-update-server/templates/deployment.yaml
@@ -3,9 +3,13 @@ kind: Deployment
 metadata:
   name: {{ include "hawkbit-update-server.fullname" . }}
   labels:
-{{ include "hawkbit-update-server.labels" . | indent 4 }}  
+{{ include "hawkbit-update-server.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- with .Values.updateStrategy }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "hawkbit-update-server.name" . }}

--- a/charts/hawkbit-update-server/templates/poddisruptionbudget.yaml
+++ b/charts/hawkbit-update-server/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt .Values.replicaCount 1.0) -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hawkbit-update-server.fullname" . }}
+  labels:
+{{ include "hawkbit-update-server.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "hawkbit-update-server.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}

--- a/charts/hawkbit-update-server/templates/service.yaml
+++ b/charts/hawkbit-update-server/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "hawkbit-update-server.fullname" . }}
   labels:
 {{ include "hawkbit-update-server.labels" . | indent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/hawkbit-update-server/values.yaml
+++ b/charts/hawkbit-update-server/values.yaml
@@ -5,12 +5,27 @@ image:
 
 replicaCount: 1
 
+## podDisruptionBudget configuration
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+## strategy used to replace old Pods by new ones
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+updateStrategy:
+  ## default is re-create, because of possible database migrations
+  type: Recreate
+
 nameOverride: ""
 fullnameOverride: ""
 
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
+    # prometheus.io/path: /actuator/prometheus
+    # prometheus.io/port: "9080"
+    # prometheus.io/scrape: "true"
 
 livenessProbe:
   initialDelaySeconds: 240


### PR DESCRIPTION
Support arbitrary service annotation (e.g. for prometheus scrape configuration)
Add PDB to ensure availability on k8s maintenance
Recreate strategy to avoid conflicts on database migrations