### PR TITLE
[fluentd-elasticsearch] Allow metrics svc to be force generated

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.1.4
+version: 5.2.0
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.1.3
+version: 5.1.4
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -112,6 +112,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceAccount.create`                      | Specifies whether a service account should be created.                         | `true`                                 |
 | `serviceAccount.name`                        | Name of the service account.                                                   | `""`                                   |
 | `serviceAccount.annotations`                 | Specify annotations in the pod service account                                                   | `{}`                                   |
+| `serviceMetric.enabled`                      | Generate the metric service regardless of whether serviceMonitor is enabled.   | `false`                                |
 | `serviceMonitor.enabled`                     | Whether to enable Prometheus serviceMonitor                                    | `false`                                |
 | `serviceMonitor.port`                        | Define on which port the ServiceMonitor should scrape                          | `24231`                                |
 | `serviceMonitor.interval`                    | Interval at which metrics should be scraped                                    | `10s`                                  |

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if or (.Values.serviceMonitor.enabled) (.Values.serviceMetric.enabled) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -198,6 +198,11 @@ serviceMonitor:
   port: 24231
   labels: {}
 
+serviceMetric:
+  ## If true, forces the metrics service to be created
+  ##
+  enabled: false
+
 prometheusRule:
   ## If true, a PrometheusRule CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -199,7 +199,8 @@ serviceMonitor:
   labels: {}
 
 serviceMetric:
-  ## If true, forces the metrics service to be created
+  ## If true, the metrics service will be created
+  ## Alternative to implicit creation through serviceMonitor.enabled
   ##
   enabled: false
 


### PR DESCRIPTION
Signed-off-by: Ben Wilson <ben.wilson+github@ukfast.co.uk>

#### What this PR does / why we need it:
  Adds a new value which lets us control whether the metrics service gets created, without having to create the service monitor. In essence this lets us decouple the servicemonitor and prometheus rule scrapes and remains backwards compatible, since the service will still get created when the servicemonitor gets enabled.

#### Which issue this PR fixes
  - fixes https://github.com/kiwigrid/helm-charts/issues/234

#### Special notes for your reviewer:
N/A

cc: @monotek  @axdotl 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
