### PR TITLE
fix deprecated PodSecurity apiVersion

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.2.0
+version: 5.2.1
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.1.3
+version: 5.1.4
 appVersion: 2.7.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podSecurityPolicy.enabled }}
+{{- if semverCompare "> 1.15" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: policy/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}


### PR DESCRIPTION
according https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ fix PodSecurity apiVersion

#### What this PR does / why we need it:

make chart compatible with k8s v1.16


@monotek @axdotl Please look at it once
