### PR TITLE
Feature/add client scope permisison

### DIFF
--- a/charts/keycloak-controller/Chart.yaml
+++ b/charts/keycloak-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for a Kubernetes controller to manage Keycloak clients and realms.
 name: keycloak-controller
-version: 0.3.0
+version: 0.4.0
 home: https://github.com/kiwigrid/keycloak-controller
 sources:
 - https://github.com/kiwigrid/keycloak-controller

--- a/charts/keycloak-controller/Chart.yaml
+++ b/charts/keycloak-controller/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.2.0"
+appVersion: "1.3.0"
 description: A Helm chart for a Kubernetes controller to manage Keycloak clients and realms.
 name: keycloak-controller
 version: 0.4.0

--- a/charts/keycloak-controller/README.md
+++ b/charts/keycloak-controller/README.md
@@ -11,7 +11,7 @@ The following table lists the configurable parameters of the chart and their def
 | ------------------------- | ---------------------------------------------------------- | ------------------------------------- |
 | `replicaCount`            | Number of replicas                                         | 1                                     |
 | `image.repository`        | keycloak-controller image                                  | `kiwigrid/keycloak-controller`        |
-| `image.tag`               | keycloak-controller image tag                              | `1.2.0`                               |
+| `image.tag`               | keycloak-controller image tag                              | `1.3.0`                               |
 | `image.pullPolicy`        | Image pull policy                                          | `IfNotPresent`                        |
 | `rbac.enabled`            | Controls RBAC usage                                        | `true`                                |
 | `retryRate`               | Configure retry interval for failed resources              | `60s`                                 |

--- a/charts/keycloak-controller/templates/rbac/role.yaml
+++ b/charts/keycloak-controller/templates/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
   - keycloaks
   - keycloakrealms
   - keycloakclients
+  - keycloakclientscopes
   verbs:
   - get
   - list

--- a/charts/keycloak-controller/values.yaml
+++ b/charts/keycloak-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: kiwigrid/keycloak-controller
-  tag: 1.2.0
+  tag: 1.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
This Pr is required for the changes in kiwigrid/keycloak-controller#14 to work, because it adds the permission to the user to access the new custom resource.