### PR TITLE
[secret-replicator] Optional PullSecrets

### DIFF
--- a/charts/secret-replicator/Chart.yaml
+++ b/charts/secret-replicator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1.1"
 description: A Helm chart to replicate secret across namespaces
 name: secret-replicator
-version: 0.4.1
+version: 0.5.0
 home: https://github.com/kiwigrid/secret-replicator
 sources:
 - https://github.com/kiwigrid/secret-replicator

--- a/charts/secret-replicator/README.md
+++ b/charts/secret-replicator/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters of the chart and their def
 | `image.repository`                           | image name                        | `kiwigrid/secret-replicator`                                                        |
 | `image.tag`                        | image tag                      | `0.1.1`                                                                                      |
 | `image.pullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
+| `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
 | `secretList`                           | list of pull secrets                          | empty string                                                        |
 | `ignoreNamespaces`             | namespaces which should be excluded from sync                                     | `kube-system,kube-pulic`               |
 | `resources`                    | Resource limits for pod             | `{}`                                   |

--- a/charts/secret-replicator/templates/deployment.yaml
+++ b/charts/secret-replicator/templates/deployment.yaml
@@ -31,8 +31,10 @@ spec:
             value: {{ .Values.ignoreNamespaces }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-      - name: registry-secret
+      - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/secret-replicator/values.yaml
+++ b/charts/secret-replicator/values.yaml
@@ -6,6 +6,10 @@ image:
   repository: kiwigrid/secret-replicator
   tag: 0.1.1
   pullPolicy: IfNotPresent
+  ## Specify ImagePullSecrets for Pods
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  # pullSecrets: myregistrykey
+
 # csv list of secrets
 secretList: ""
 # secretList: "secret1,secret2


### PR DESCRIPTION
### What this PR does / why we need it:

Removed hard-coded ImagePullSecrets from secret-replicator. In my deployment I don't need image pull secrets for deployment, and having hardcoded pull secret defined in deployment causes annoying (but harmless) errors in logs. Just clearing up noise.
Also, this allows actually customise secret name that is used for pulling images for this deployment.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
