### PR TITLE
[fluentd-elasticsearch] Ensure concat plugin does not drop messages.

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.3.2
+version: 5.3.3
 appVersion: 2.8.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -155,6 +155,8 @@ data:
       key message
       multiline_end_regexp /\n$/
       separator ""
+      timeout_label @NORMAL
+      flush_interval 5
     </filter>
 
     # Enriches records with Kubernetes metadata
@@ -467,6 +469,13 @@ data:
 
 {{- if .Values.configMaps.useDefaults.outputConf }}
   output.conf: |-
+    # handle timeout log lines from concat plugin
+    <match **>
+      @type relabel
+      @label @NORMAL
+    </match>
+
+    <label @NORMAL>
     <match **>
       @id elasticsearch
       @type elasticsearch
@@ -502,6 +511,7 @@ data:
         overflow_action block
       </buffer>
     </match>
+    </label>
 {{- end }}
 
 {{- range $key, $value := .Values.extraConfigMaps }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This fix ensures that if fluentd concat plugin generates error due to
timeout in processing, then message will be processed by other filters
and thus end in elasticsearch (even if not fully parsed).

Fixes error messages such as:

```text
[warn]: dump an error event:
error_class=Fluent::Plugin::ConcatFilter::TimeoutError
error="Timeout flush: node-problem-detector:default"
location=nil ...
```

For reference see:
https://github.com/fluent-plugins-nursery/fluent-plugin-concat#usage
or
https://github.com/helm/charts/pull/16871 under path
stable/sumologic-fluentd/files/file.source.containers.conf

Signed-off-by: Michał Sochoń <kaszpir@gmail.com>

#### Which issue this PR fixes
  - fixes #265 

#### Special notes for your reviewer:

Two notes:
- I believe bumping only patch version is sufficient, the code is backward compatible
- I have explicitly not indented the code between tags to minimize the difference due to indentation - do you want me to fix this?

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
