### PR TITLE
[fluentd-elasticsearch] Add systemd field strip underscores and field lowercase to other sources

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.4.0
+version: 6.0.0
 appVersion: 2.8.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 5.3.3
+version: 5.4.0
 appVersion: 2.8.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -155,17 +155,25 @@ extraVolumes: |
 
 ## Upgrading
 
-When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--force" parameter to your helm upgrade command as there have been changes to the lables which makes a normal upgrade impossible.
+### From a version < 2.0.0 
 
-When upgrading this chart from a version &ge; 4.9.3 to version &ge; 5.0.0, you need to rename `livenessProbe.command` parameter to `livenessProbe.kind.exec.command` (only applicable if `livenessProbe.command` parameter was used).
+When you upgrade this chart you have to add the "--force" parameter to your helm upgrade command as there have been changes to the lables which makes a normal upgrade impossible.
 
-When upgrading this chart from a version &lt; 6.0.0 to version &ge; 6.0.0
-you have to perform updates for any system that uses fluentd output from
-systemd logs, because now:
+### From a version &ge; 4.9.3 to version &ge; 5.0.0
+
+When upgrading this chart you need to rename `livenessProbe.command` parameter to `livenessProbe.kind.exec.command` (only applicable if `livenessProbe.command` parameter was used).
+
+### From a version &lt; 6.0.0 to version &ge; 6.0.0
+
+When upgrading this chart  you have to perform updates for any system that 
+uses fluentd output from systemd logs, because now:
+
 - field names have removed leading underscores (`_pid` becomes `pid`)
 - field names from systemd are now lowercase (`PROCESS` becomes `process`)
+
 This means any system that uses fluend output needs to be updated,
 especially:
+
 - in Kibana go to `Management > Index Patterns`, for each index click on
    `Refresh field list` icon
 - fix renamed fields in other places - such as Kibana or Grafana, in items

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -159,6 +159,64 @@ When you upgrade this chart from a version &lt; 2.0.0 you have to add the "--for
 
 When upgrading this chart from a version &ge; 4.9.3 to version &ge; 5.0.0, you need to rename `livenessProbe.command` parameter to `livenessProbe.kind.exec.command` (only applicable if `livenessProbe.command` parameter was used).
 
+When upgrading this chart from a version &lt; 6.0.0 to version &ge; 6.0.0
+you have to perform updates for any system that uses fluentd output from
+systemd logs, because now:
+- field names have removed leading underscores (`_pid` becomes `pid`)
+- field names from systemd are now lowercase (`PROCESS` becomes `process`)
+This means any system that uses fluend output needs to be updated,
+especially:
+- in Kibana go to `Management > Index Patterns`, for each index click on
+   `Refresh field list` icon
+- fix renamed fields in other places - such as Kibana or Grafana, in items
+  such as dashboards queries/vars/annotations
+
+It is strongly suggested to set up temporarily new fluend instance with output 
+to another elasticsearch index prefix to see the differences and then apply changes. The amount of fields altered can be noticeable and hard to list them all in this document.
+
+Some dashboards can be easily fixed with sed:
+
+```bash
+cat dashboard.json | sed -e 's/_PID/pid/g'
+```
+
+Below list of most commonly used systemd fields:
+
+```text
+__MONOTONIC_TIMESTAMP
+__REALTIME_TIMESTAMP
+_BOOT_ID
+_CAP_EFFECTIVE
+_CMDLINE
+_COMM
+_EXE
+_GID
+_HOSTNAME
+_MACHINE_ID
+_PID
+_SOURCE_REALTIME_TIMESTAMP
+_SYSTEMD_CGROUP
+_SYSTEMD_SLICE
+_SYSTEMD_UNIT
+_TRANSPORT
+_UID
+CODE_FILE
+CODE_FUNC
+CODE_FUNCTION
+CODE_LINE
+MESSAGE
+MESSAGE_ID
+NM_LOG_DOMAINS
+NM_LOG_LEVEL
+PRIORITY
+SYSLOG_FACILITY
+SYSLOG_IDENTIFIER
+SYSLOG_PID
+TIMESTAMP_BOOTTIME
+TIMESTAMP_MONOTONIC
+UNIT
+```
+
 ## AWS Elasticsearch Domains
 
 AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: {enabled: true}` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -153,6 +153,11 @@ extraVolumes: |
         type: Directory
 ```
 
+### AWS Elasticsearch Domains
+
+AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: {enabled: true}` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.
+
+
 ## Upgrading
 
 ### From a version < 2.0.0 
@@ -225,6 +230,4 @@ TIMESTAMP_MONOTONIC
 UNIT
 ```
 
-## AWS Elasticsearch Domains
 
-AWS Elasticsearch requires requests to upload data to be signed using [AWS Signature V4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). In order to support this, you can add `awsSigningSidecar: {enabled: true}` to your configuration. This results in a sidecar container being deployed that proxies all requests to your Elasticsearch domain and signs them appropriately.

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -355,6 +355,10 @@ data:
         persistent true
         path /var/log/journald-docker.pos
       </storage>
+      <entry>
+        fields_strip_underscores true
+        fields_lowercase true
+      </entry>
       read_from_head true
       tag docker
     </source>
@@ -368,6 +372,10 @@ data:
         persistent true
         path /var/log/journald-container-runtime.pos
       </storage>
+      <entry>
+        fields_strip_underscores true
+        fields_lowercase true
+      </entry>
       read_from_head true
       tag container-runtime
     </source>
@@ -381,6 +389,10 @@ data:
         persistent true
         path /var/log/journald-kubelet.pos
       </storage>
+      <entry>
+        fields_strip_underscores true
+        fields_lowercase true
+      </entry>
       read_from_head true
       tag kubelet
     </source>
@@ -394,6 +406,10 @@ data:
         persistent true
         path /var/log/journald-node-problem-detector.pos
       </storage>
+      <entry>
+        fields_strip_underscores true
+        fields_lowercase true
+      </entry>
       read_from_head true
       tag node-problem-detector
     </source>


### PR DESCRIPTION
#### What this PR does / why we need it:

Ensure that field names are all lowercase.
Ensure that fields do not start with underscore.

Both above options makes fields indexable by elasticsearch, improving
ability to search for the desired content.

Unfortunately this will break dashboards/queries that expect
that certain fields are starting with underscore or are all in capital
letters.

Example:
`_PID` will become `pid`
`PRIORITY` will become `priority`
`_some_field` will become `some_field`

For reference please see:
https://github.com/fluent-plugin-systemd/fluent-plugin-systemd#filter-plugin-configuration

Signed-off-by: Michał Sochoń <kaszpir@gmail.com>

#### Which issue this PR fixes
  - fixes #264 


#### Special notes for your reviewer:

This is a breaking change.
I only bumped major version because it is just configuration change for fluentd itself.

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
