### PR TITLE
fluentd-elasticsearch: Support adding relabelings to ServiceMonitor

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 6.0.0
+version: 6.1.0
 appVersion: 2.8.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -118,6 +118,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceMonitor.interval`                    | Interval at which metrics should be scraped                                    | `10s`                                  |
 | `serviceMonitor.path`                        | Path for Metrics                                                               | `/metrics`                             |
 | `serviceMonitor.labels`                      | Optional labels for serviceMonitor                                             | `{}`                                   |
+| `serviceMonitor.metricRelabelings`           | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                   |
+| `serviceMonitor.relabelings`                 | Optional relabel configs to apply to samples before scraping                   | `[]`                                   |
 | `tolerations`                                | Optional daemonset tolerations                                                 | `[]`                                   |
 | `updateStrategy`                             | Optional daemonset update strategy                                             | `type: RollingUpdate`                  |
 | `additionalPlugins`                          | Optional additionnal plugins to install when pod starts                        | `{}`                                   |

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -18,6 +18,14 @@ spec:
     honorLabels: true
     port: metrics
     path: {{ .Values.serviceMonitor.path }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -197,6 +197,8 @@ serviceMonitor:
   path: /metrics
   port: 24231
   labels: {}
+  metricRelabelings: []
+  relabelings: []
 
 serviceMetric:
   ## If true, the metrics service will be created


### PR DESCRIPTION
Signed-off-by: Robin Ketelbuters <robin.ketelbuters@gmail.be>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds support for filling in the relabelings and metricRelabelings fields in the ServiceMonitor definition for fluentd-elasticsearch.
For my specific use-case, I want to add labels to the `fluentd_tail_file_position` metric by extracting the information from the `path` label.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
