### PR TITLE
[graphite] Ability to setup initContainers on-demand

### DIFF
--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.4.0
+version: 0.5.0
 appVersion: "1.1.5-4"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/README.md
+++ b/charts/graphite/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the Graphite chart and 
 | `tolerations`                  | Tolerations                                  | `[]`                                   |
 | `affinity`                     | Affinity                                     | `{}`                                   |
 | `timeZone`                     | Timezone                                     | `Etc/UTC`                              |
+| `initContainers`               | Init Containers                              | `[]`                                   |
 | `configMaps`                   | Graphite Config files                        | see values.yaml                        |
 | `statsdConfigMaps`             | StatsD Config files                          | see values.yaml                        |
 | `statsd.interface`             | StatsD server interface, `TCP` or `UDP`      | `UDP`                                  |

--- a/charts/graphite/templates/statefulset.yaml
+++ b/charts/graphite/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/name: {{ include "graphite.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 8 }}
+{{- end }}
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: {{ .Chart.Name }}

--- a/charts/graphite/values.yaml
+++ b/charts/graphite/values.yaml
@@ -60,6 +60,16 @@ affinity: {}
 
 timeZone: Etc/UTC
 
+initContainers: []
+#  - name: init-sysctl
+#    image: busybox
+#    command:
+#      - sysctl
+#      - -w
+#      - net.core.somaxconn=65535
+#    securityContext:
+#      privileged: true
+
 configMaps:
   aggregation-rules.conf: |-
     # The form of each line in this file should be as follows:


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
[initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) helps us to fine-tune `Pod`'s kernel parameters on-demand whatever the need is.



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
