### PR TITLE
[prometheus-thanos] Add parameter to create service accounts

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.6.1
+version: 2.7.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -74,6 +74,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.image.repository` | Docker image repo for bucket web interface | `quay.io/thanos/thanos` |
 | `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.10.0` |
 | `bucketWebInterface.image.pullPolicy` | Docker image pull policy for bucket web interface| `IfNotPresent` |
+| `bucketWebInterface.serviceAccount.create` | Create service account | `true` |
+| `bucketWebInterface.serviceAccount.annotations` | Service account annotations | `nil` |
 | `bucketWebInterface.logLevel` | Bucket web interface log level | `info` |
 | `bucketWebInterface.nodeSelector` | NodeSelector | `{}` |
 | `bucketWebInterface.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
@@ -95,6 +97,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
 | `compact.image.tag` | Docker image tag for store gateway | `v0.10.0` |
 | `compact.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
+| `compact.serviceAccount.create` | Create service account | `true` |
+| `compact.serviceAccount.annotations` | Service account annotations | `nil` |
 | `compact.logLevel` | Store gateway log level | `info` |
 | `compact.nodeSelector` | NodeSelector | `{}` |
 | `compact.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
@@ -122,6 +126,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
 | `querier.image.tag` | Docker image tag for querier | `v0.10.0` |
 | `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
+| `querier.serviceAccount.create` | Create service account | `true` |
+| `querier.serviceAccount.annotations` | Service account annotations | `nil` |
 | `querier.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `querier.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
 | `querier.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
@@ -152,6 +158,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
 | `ruler.image.tag` | Docker image tag for ruler | `v0.10.0` |
 | `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
+| `ruler.serviceAccount.annotations` | Service account annotations | `nil` |
 | `ruler.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `ruler.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
 | `ruler.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
@@ -205,6 +212,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
 | `storeGateway.image.tag` | Docker image tag for store gateway | `v0.10.0` |
 | `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
+| `storeGateway.serviceAccount.create` | Create service account | `true` |
+| `storeGateway.serviceAccount.annotations` | Service account annotations | `nil` |
 | `storeGateway.indexCacheSize` | Index cache size | `500MB` |
 | `storeGateway.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `storeGateway.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -34,6 +34,9 @@ spec:
         {{- end }}
     {{- end }}
     spec:
+      {{- if .Values.bucketWebInterface.serviceAccount.create }}
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-bucket-web-interface
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-bucket-web-interface
           imagePullPolicy: {{ .Values.bucketWebInterface.image.pullPolicy }}

--- a/charts/prometheus-thanos/templates/bucket-web-serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.bucketWebInterface.enabled .Values.bucketWebInterface.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-bucket-web-interface
+{{- if .Values.bucketWebInterface.serviceAccount.annotations }}
+      annotations:
+{{ toYaml .Values.bucketWebInterface.serviceAccount.annotations | indent 8 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/compact-serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/compact-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.compact.enabled .Values.compact.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-compact
+{{- if .Values.compact.serviceAccount.annotations }}
+      annotations:
+{{ toYaml .Values.compact.serviceAccount.annotations | indent 8 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-compact
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -32,6 +32,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.compact.serviceAccount.create }}
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-compact
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-compact
           imagePullPolicy: {{ .Values.compact.image.pullPolicy }}

--- a/charts/prometheus-thanos/templates/querier-deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier-deployment.yaml
@@ -34,6 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.querier.serviceAccount.create }}
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-querier
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-querier
           imagePullPolicy: {{ .Values.querier.image.pullPolicy }}

--- a/charts/prometheus-thanos/templates/querier-serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/querier-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.querier.enabled .Values.querier.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-querier
+{{- if .Values.querier.serviceAccount.annotations }}
+      annotations:
+{{ toYaml .Values.querier.serviceAccount.annotations | indent 8 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-querier
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/ruler-serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/ruler-serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-ruler
+{{- if .Values.ruler.serviceAccount.annotations }}
+      annotations:
+{{ toYaml .Values.ruler.serviceAccount.annotations | indent 8 }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-ruler
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -94,7 +94,7 @@ spec:
             initialDelaySeconds: {{ .Values.ruler.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.ruler.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.ruler.readinessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.ruler.readinessProbe.timeoutSeconds }}              
+            timeoutSeconds: {{ .Values.ruler.readinessProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.ruler.resources | nindent 12 }}
           volumeMounts:

--- a/charts/prometheus-thanos/templates/store-gateway-serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.storeGateway.enabled .Values.storeGateway.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-store-gateway
+{{- if .Values.storeGateway.serviceAccount.annotations }}
+      annotations:
+{{ toYaml .Values.storeGateway.serviceAccount.annotations | indent 8 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-store-gateway
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
@@ -33,6 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.storeGateway.serviceAccount.create }}
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-store-gateway
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-store-gateway
           imagePullPolicy: {{ .Values.storeGateway.image.pullPolicy }}
@@ -48,7 +51,7 @@ spec:
           {{- end }}
           {{- if .Values.storeGateway.objStoreType }}
           - |
-            --objstore.config=type: {{ .Values.storeGateway.objStoreType }} 
+            --objstore.config=type: {{ .Values.storeGateway.objStoreType }}
             config:
             {{- toYaml .Values.storeGateway.objStoreConfig | nindent 14 }}
           {{ else if .Values.storeGateway.objStoreConfigFile }}
@@ -63,7 +66,7 @@ spec:
               protocol: TCP
           {{- if .Values.storeGateway.extraEnv }}
           env:
-            {{- toYaml .Values.storeGateway.extraEnv | nindent 12 }}  
+            {{- toYaml .Values.storeGateway.extraEnv | nindent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -41,6 +41,11 @@ querier:
     repository: quay.io/thanos/thanos
     tag: v0.10.0
     pullPolicy: IfNotPresent
+  serviceAccount:
+    create: false
+  #  annotations: eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+  ## See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+  ## for IAM Role for your Service Account usage
   additionalLabels: {}
   additionalAnnotations: {}
   replicaLabel: replica
@@ -70,6 +75,8 @@ storeGateway:
     repository: quay.io/thanos/thanos
     tag: v0.10.0
     pullPolicy: IfNotPresent
+  serviceAccount:
+    create: false
   additionalLabels: {}
   additionalAnnotations: {}
   extraEnv: []
@@ -125,6 +132,8 @@ compact:
     repository: quay.io/thanos/thanos
     tag: v0.10.0
     pullPolicy: IfNotPresent
+  serviceAccount:
+    create: false
   additionalLabels: {}
   additionalAnnotations: {}
   logLevel: info
@@ -181,6 +190,7 @@ ruler:
       repository: kiwigrid/k8s-configmap-watcher
       tag: 0.1.1
       pullPolicy: IfNotPresent
+  serviceAccount: {}
   replicaLabel: replica
   logLevel: info
   ## Ruler configuration
@@ -252,6 +262,8 @@ bucketWebInterface:
     repository: quay.io/thanos/thanos
     tag: v0.10.0
     pullPolicy: IfNotPresent
+  serviceAccount:
+    create: false
   logLevel: info
   objStoreType: null
   objStoreConfig: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
To use Web Identity providers for IAM credentials for AWS EKS we need a kubrnetes service account with specific annotation.
This PR add a service account for each thanos component with an annotation option.

Related thanos fixed issue: https://github.com/thanos-io/thanos/issues/1494


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
