### PR TITLE
[Prometheus-Thanos] - Add podPriority and podPriorityClassName

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.7.0
+version: 2.8.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -81,8 +81,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
 | `bucketWebInterface.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
 | `bucketWebInterface.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
-| `bucketWebInterface.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
-| `bucketWebInterface.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
+| `bucketWebInterface.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`. | `false` |
+| `bucketWebInterface.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `bucketWebInterface.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
 | `bucketWebInterface.replicaCount` | Replica count for bucket web interface | `1` |
 | `bucketWebInterface.resources` | Resources | `{}` |
 | `bucketWebInterface.tolerations` | Tolerations | `[]` |
@@ -112,8 +113,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
 | `compact.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `compact.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
-| `compact.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
-| `compact.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
+| `compact.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`. | `false` |
+| `compact.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `compact.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
 | `compact.resources` | Resources | `{}` |
 | `compact.retentionResolutionRaw` | Retention for raw buckets | `30d` |
 | `compact.retentionResolution5m` | Retention for 5m buckets | `120d` |
@@ -138,8 +140,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.livenessProbe.timeoutSeconds` | Liveness probe timeoutSeconds | `30` |
 | `querier.logLevel` | Querier log level | `info` |
 | `querier.nodeSelector` | NodeSelector | `{}` |
-| `querier.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
-| `querier.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
+| `querier.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`. | `false` |
+| `querier.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `querier.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
 | `querier.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
 | `querier.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
 | `querier.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
@@ -180,8 +183,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
 | `ruler.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `ruler.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
-| `ruler.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
-| `ruler.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
+| `ruler.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`.| `false` |
+| `ruler.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `ruler.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
 | `ruler.queries` | Ruler quieries endpoints | `[]` |
 | `ruler.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
 | `ruler.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
@@ -238,8 +242,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.persistentVolume.existingClaim` | Persistent volume existingClaim | `` |
 | `storeGateway.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `storeGateway.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
-| `storeGateway.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
-| `storeGateway.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
+| `storeGateway.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`. | `false` |
+| `storeGateway.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `storeGateway.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
 | `storeGateway.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
 | `storeGateway.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
 | `storeGateway.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -81,6 +81,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `nil` |
 | `bucketWebInterface.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
 | `bucketWebInterface.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
+| `bucketWebInterface.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
+| `bucketWebInterface.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
 | `bucketWebInterface.replicaCount` | Replica count for bucket web interface | `1` |
 | `bucketWebInterface.resources` | Resources | `{}` |
 | `bucketWebInterface.tolerations` | Tolerations | `[]` |
@@ -110,6 +112,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
 | `compact.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `compact.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `compact.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
+| `compact.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
 | `compact.resources` | Resources | `{}` |
 | `compact.retentionResolutionRaw` | Retention for raw buckets | `30d` |
 | `compact.retentionResolution5m` | Retention for 5m buckets | `120d` |
@@ -134,6 +138,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.livenessProbe.timeoutSeconds` | Liveness probe timeoutSeconds | `30` |
 | `querier.logLevel` | Querier log level | `info` |
 | `querier.nodeSelector` | NodeSelector | `{}` |
+| `querier.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
+| `querier.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
 | `querier.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
 | `querier.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
 | `querier.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
@@ -174,6 +180,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
 | `ruler.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `ruler.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `ruler.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
+| `ruler.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
 | `ruler.queries` | Ruler quieries endpoints | `[]` |
 | `ruler.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
 | `ruler.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
@@ -230,6 +238,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.persistentVolume.existingClaim` | Persistent volume existingClaim | `` |
 | `storeGateway.persistentVolume.size` | Persistent volume size | `2Gi` |
 | `storeGateway.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `storeGateway.podPriority` | Numerical value of the pod priority. Either this or `podPriorityClassName`. `-1` disables this. | `-1` |
+| `storeGateway.podPriorityClassName` | Name of the pod priority class to use. Either this or `podPriority` | `""` |
 | `storeGateway.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
 | `storeGateway.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
 | `storeGateway.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -86,7 +86,7 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if ne .Values.bucketWebInterface.podPriority -1.0 }}
+    {{- if .Values.bucketWebInterface.podNumericalPriorityEnabled }}
       priority: {{ .Values.bucketWebInterface.podPriority }}
     {{- else if .Values.bucketWebInterface.podPriorityClassName }}
       priorityClassName: {{ .Values.bucketWebInterface.podPriorityClassName }}

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -86,4 +86,9 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ne .Values.bucketWebInterface.podPriority -1.0 }}
+      priority: {{ .Values.bucketWebInterface.podPriority }}
+    {{- else if .Values.bucketWebInterface.podPriorityClassName }}
+      priorityClassName: {{ .Values.bucketWebInterface.podPriorityClassName }}
+    {{- end }}
 {{- end }}

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if ne .Values.compact.podPriority -1.0 }}
+    {{- if .Values.compact.podNumericalPriorityEnabled }}
       priority: {{ .Values.compact.podPriority }}
     {{- else if .Values.compact.podPriorityClassName }}
       priorityClassName: {{ .Values.compact.podPriorityClassName }}

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -89,6 +89,11 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ne .Values.compact.podPriority -1.0 }}
+      priority: {{ .Values.compact.podPriority }}
+    {{- else if .Values.compact.podPriorityClassName }}
+      priorityClassName: {{ .Values.compact.podPriorityClassName }}
+    {{- end }}
     {{- if .Values.compact.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/prometheus-thanos/templates/querier-deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier-deployment.yaml
@@ -96,7 +96,7 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if ne .Values.querier.podPriority -1.0 }}
+    {{- if .Values.querier.podNumericalPriorityEnabled }}
       priority: {{ .Values.querier.podPriority }}
     {{- else if .Values.querier.podPriorityClassName }}
       priorityClassName: {{ .Values.querier.podPriorityClassName }}

--- a/charts/prometheus-thanos/templates/querier-deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier-deployment.yaml
@@ -96,4 +96,9 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ne .Values.querier.podPriority -1.0 }}
+      priority: {{ .Values.querier.podPriority }}
+    {{- else if .Values.querier.podPriorityClassName }}
+      priorityClassName: {{ .Values.querier.podPriorityClassName }}
+    {{- end }}
 {{- end }}

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -156,7 +156,7 @@ spec:
     {{- with .Values.ruler.volumes }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if ne .Values.ruler.podPriority -1.0 }}
+    {{- if .Values.ruler.podNumericalPriorityEnabled }}
       priority: {{ .Values.ruler.podPriority }}
     {{- else if .Values.ruler.podPriorityClassName }}
       priorityClassName: {{ .Values.ruler.podPriorityClassName }}

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -156,6 +156,11 @@ spec:
     {{- with .Values.ruler.volumes }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ne .Values.ruler.podPriority -1.0 }}
+      priority: {{ .Values.ruler.podPriority }}
+    {{- else if .Values.ruler.podPriorityClassName }}
+      priorityClassName: {{ .Values.ruler.podPriorityClassName }}
+    {{- end }}
 {{- if .Values.ruler.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if ne .Values.storeGateway.podPriority -1.0 }}
+    {{- if .Values.storeGateway.podNumericalPriorityEnabled }}
       priority: {{ .Values.storeGateway.podPriority }}
     {{- else if .Values.storeGateway.podPriorityClassName }}
       priorityClassName: {{ .Values.storeGateway.podPriorityClassName }}

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
@@ -108,6 +108,11 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ne .Values.storeGateway.podPriority -1.0 }}
+      priority: {{ .Values.storeGateway.podPriority }}
+    {{- else if .Values.storeGateway.podPriorityClassName }}
+      priorityClassName: {{ .Values.storeGateway.podPriorityClassName }}
+    {{- end }}
 {{- if .Values.storeGateway.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -54,6 +54,9 @@ querier:
   additionalFlags: {}
   resources: {}
   nodeSelector: {}
+  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
+  podPriority: -1
+  podPriorityClassName: ""
   tolerations: []
   affinity: {}
   livenessProbe:
@@ -99,6 +102,9 @@ storeGateway:
   #  endpoint: a
   #  insecure: true
   objStoreConfigFile: null
+  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
+  podPriority: -1
+  podPriorityClassName: ""
 
   resources: {}
   nodeSelector: {}
@@ -155,6 +161,9 @@ compact:
   #  endpoint: a
   #  insecure: true
   objStoreConfigFile: null
+  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
+  podPriority: -1
+  podPriorityClassName: ""
 
   extraEnv: []
   # - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -250,6 +259,9 @@ ruler:
     existingClaim: ""
     size: 2Gi
     storageClass: ""
+  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
+  podPriority: -1
+  podPriorityClassName: ""
 
 bucketWebInterface:
   enabled: false
@@ -278,6 +290,9 @@ bucketWebInterface:
   #  insecure: true
   objStoreConfigFile: null
   nodeSelector: {}
+  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
+  podPriority: -1
+  podPriorityClassName: ""
   replicaCount: 1
   resources: {}
   tolerations: []

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -54,8 +54,8 @@ querier:
   additionalFlags: {}
   resources: {}
   nodeSelector: {}
-  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
-  podPriority: -1
+  podNumericalPriorityEnabled: false
+  podPriority: 0
   podPriorityClassName: ""
   tolerations: []
   affinity: {}
@@ -102,8 +102,8 @@ storeGateway:
   #  endpoint: a
   #  insecure: true
   objStoreConfigFile: null
-  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
-  podPriority: -1
+  podNumericalPriorityEnabled: false
+  podPriority: 0
   podPriorityClassName: ""
 
   resources: {}
@@ -161,8 +161,8 @@ compact:
   #  endpoint: a
   #  insecure: true
   objStoreConfigFile: null
-  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
-  podPriority: -1
+  podNumericalPriorityEnabled: false
+  podPriority: 0
   podPriorityClassName: ""
 
   extraEnv: []
@@ -259,8 +259,8 @@ ruler:
     existingClaim: ""
     size: 2Gi
     storageClass: ""
-  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
-  podPriority: -1
+  podNumericalPriorityEnabled: true
+  podPriority: 0
   podPriorityClassName: ""
 
 bucketWebInterface:
@@ -290,8 +290,8 @@ bucketWebInterface:
   #  insecure: true
   objStoreConfigFile: null
   nodeSelector: {}
-  # -1 is used to disable adding a podPriority as 0 is a valid value for pod priorities
-  podPriority: -1
+  podNumericalPriorityEnabled: false
+  podPriority: 0
   podPriorityClassName: ""
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
Adds the ability to set priority or priorityClassName on all pod specs.

#### What this PR does / why we need it:

Adds the ability to independently set `priority` or `priorityClassName` on all pod specs within Prometheus-Thanos.

We have enabled pod priorities on our clusters and want to set our monitoring related pods as higher priority than our user workloads to ensure we don't risk losing visibility of our cluster state during fast scaling.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
