### PR TITLE
[prometheus-thanos] Add Thanos querier and store gateway autoscaling

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.8.0
+version: 2.9.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -129,6 +129,10 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.additionalFlags` | Additional command line flags | `{}` |
 | `querier.additionalLabels` | Additional labels on querier pods| `{}` |
 | `querier.affinity` | Affinity | `{}` |
+| `querier.autoscaling.enabled` | Controls whether StoreGateway autoscaling is enabled | `false` |
+| `querier.autoscaling.maxReplicas` | Maximum number of replicas to scale to | `10` |
+| `querier.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
+| `querier.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
 | `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
 | `querier.image.tag` | Docker image tag for querier | `v0.10.0` |
 | `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
@@ -219,6 +223,10 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.additionalAnnotations` | Additional annotations on store gateway pods| `{}` |
 | `storeGateway.additionalFlags` | Additional command line flags | `{}` |
 | `storeGateway.additionalLabels` | Additional labels on store gateway pods| `{}` |
+| `storeGateway.autoscaling.enabled` | Controls whether StoreGateway autoscaling is enabled | `false` |
+| `storeGateway.autoscaling.maxReplicas` | Maximum number of replicas to scale to | `10` |
+| `storeGateway.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
+| `storeGateway.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
 | `storeGateway.chunkPoolSize` | Chunk pool size | `500MB` |
 | `storeGateway.extraEnv` | Extra env vars | `nil` |
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |

--- a/charts/prometheus-thanos/templates/querier-deployment-hpa.yaml
+++ b/charts/prometheus-thanos/templates/querier-deployment-hpa.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.querier.enabled .Values.querier.autoscaling.enabled -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-querier
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-querier
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "prometheus-thanos.fullname" . }}-querier
+  minReplicas: {{ .Values.querier.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.querier.autoscaling.maxReplicas }}
+{{- with .Values.querier.autoscaling.metrics }}
+  metrics: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset-hpa.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset-hpa.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.storeGateway.enabled .Values.storeGateway.autoscaling.enabled -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-store-gateway
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-store-gateway
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "prometheus-thanos.fullname" . }}-store-gateway
+  minReplicas: {{ .Values.storeGateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.storeGateway.autoscaling.maxReplicas }}
+{{ with  .Values.storeGateway.autoscaling.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -70,6 +70,26 @@ querier:
     successThreshold: 1
     timeoutSeconds: 30
 
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+    # List of MetricSpecs to decide whether to scale
+    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+
 storeGateway:
   enabled: true
   replicaCount: 1
@@ -130,6 +150,26 @@ storeGateway:
     existingClaim: ""
     size: 2Gi
     storageClass: ""
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+    # List of MetricSpecs to decide whether to scale
+    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
 
 compact:
   enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds an autoscaling config for the querier and store gateway in the
prometheus-thanos chart.
The metrics to scale on can be defined in the autoscaling sections of
the respective objects as MetricSpecs.

Autoscaling is disabled by default.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #285


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
