### PR TITLE
[prometheus-thanos] - Allow bucket web httpPort specification

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.10.0"
+appVersion: "0.10.1"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.9.0
+version: 2.9.1
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.additionalLabels` | Additional labels on bucket web interface pods| `{}` |
 | `bucketWebInterface.affinity` | Affinity | `{}` |
 | `bucketWebInterface.extraEnv` | Extra env vars | `nil` |
+| `bucketWebInterface.httpServerPort` | The port to expose from the bucket web interface container | `10902` |
 | `bucketWebInterface.image.repository` | Docker image repo for bucket web interface | `quay.io/thanos/thanos` |
 | `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.10.0` |
 | `bucketWebInterface.image.pullPolicy` | Docker image pull policy for bucket web interface| `IfNotPresent` |

--- a/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web-deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.bucketWebInterface.httpServerPort }}
               protocol: TCP
           {{- if .Values.bucketWebInterface.extraEnv }}
           env:

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -310,6 +310,7 @@ bucketWebInterface:
   additionalLabels: {}
   affinity: {}
   extraEnv: []
+  httpServerPort: 10902
   image:
     repository: quay.io/thanos/thanos
     tag: v0.10.0


### PR DESCRIPTION
#### What this PR does / why we need it:

As of version 0.9 there was a rationalisation of startup of HTTP components of Thanos. This meant that the `bucket web` component moved from being served on port `8080` to `10902` as with the other HTTP components. (See https://github.com/thanos-io/thanos/pull/1687). This isn't strictly necessary to still port-forward to the container as long as users correctly figure out the port however could lead to usability issues and issues with other tooling.

#### Which issue this PR fixes

N/A


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
