### PR TITLE
[prometheus-thanos] - Update to v0.10.1

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.1"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.9.1
+version: 2.10.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.extraEnv` | Extra env vars | `nil` |
 | `bucketWebInterface.httpServerPort` | The port to expose from the bucket web interface container | `10902` |
 | `bucketWebInterface.image.repository` | Docker image repo for bucket web interface | `quay.io/thanos/thanos` |
-| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.10.0` |
+| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.10.1` |
 | `bucketWebInterface.image.pullPolicy` | Docker image pull policy for bucket web interface| `IfNotPresent` |
 | `bucketWebInterface.serviceAccount.create` | Create service account | `true` |
 | `bucketWebInterface.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -99,7 +99,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.consistencyDelay` | Consistency delay | `30m` |
 | `compact.extraEnv` | Extra env vars | `nil` |
 | `compact.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
-| `compact.image.tag` | Docker image tag for store gateway | `v0.10.0` |
+| `compact.image.tag` | Docker image tag for store gateway | `v0.10.1` |
 | `compact.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
 | `compact.serviceAccount.create` | Create service account | `true` |
 | `compact.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
 | `querier.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
 | `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
-| `querier.image.tag` | Docker image tag for querier | `v0.10.0` |
+| `querier.image.tag` | Docker image tag for querier | `v0.10.1` |
 | `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
 | `querier.serviceAccount.create` | Create service account | `true` |
 | `querier.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -170,7 +170,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.evalInterval` | Ruler evaluation interval | `1m` |
 | `ruler.extraEnv` | Extra env vars | `nil` |
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
-| `ruler.image.tag` | Docker image tag for ruler | `v0.10.0` |
+| `ruler.image.tag` | Docker image tag for ruler | `v0.10.1` |
 | `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
 | `ruler.serviceAccount.annotations` | Service account annotations | `nil` |
 | `ruler.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
@@ -231,7 +231,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.chunkPoolSize` | Chunk pool size | `500MB` |
 | `storeGateway.extraEnv` | Extra env vars | `nil` |
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
-| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.10.0` |
+| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.10.1` |
 | `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
 | `storeGateway.serviceAccount.create` | Create service account | `true` |
 | `storeGateway.serviceAccount.annotations` | Service account annotations | `nil` |

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -39,7 +39,7 @@ querier:
       maxUnavailable: 0
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.10.0
+    tag: v0.10.1
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -96,7 +96,7 @@ storeGateway:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.10.0
+    tag: v0.10.1
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -176,7 +176,7 @@ compact:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.10.0
+    tag: v0.10.1
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -230,7 +230,7 @@ ruler:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.10.0
+    tag: v0.10.1
     pullPolicy: IfNotPresent
   sidecar:
     enabled: false
@@ -313,7 +313,7 @@ bucketWebInterface:
   httpServerPort: 10902
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.10.0
+    tag: v0.10.1
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false


### PR DESCRIPTION
Signed-off-by: GuyTempleton <guy.templeton@skyscanner.net>

#### What this PR does / why we need it:

Realised this morning that #287 accidentally managed to bump the app version as well as the chart version (made my usual mistake of confusing the two to begin with.) Came back to correct my mistake and realised the upstream v0.10.1 release has been cut.

Pulls in the fix documented here: https://github.com/thanos-io/thanos/blob/v0.10.1/CHANGELOG.md#v0101---20200123 

Note that as per the [thread comment here](https://github.com/thanos-io/thanos/pull/2015#issuecomment-577586302) the querier needs to be updated to this release to resolve the issue, not just the sidecar despite the release note implying this, hence why it benefits this chart.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
