### PR TITLE
[prometheus-thanos] Make the cache for the store gateway configurable

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.1"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 2.10.0
+version: 3.0.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -59,6 +59,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 > **Tip**: To completely remove the release, run `helm delete --purge prometheus-thanos`
 
+## Upgrading
+
+This section describes instructions on how to upgrade from a previous version of this chart and breaking changes.
+
+### 3.x
+
+There was a breaking change in version 3.0.0 which removed the `storeGateway.indexCacheSize` setting in favour of a `storeGateway.indexCache` config object.
+If you're upgrading from a pre-3.0.0 version of this chart, your config needs to adapt the new format.
+
+For example, if you had previously set `storeGateway.indexCacheSize` to `500MB`, you need to set `storeGateway.indexCache` to the following:
+
+```yaml
+indexCache:
+  type: IN-MEMORY
+  config:
+    max_size: 500MB
+```
+
+All configuration options can be found in [the documentation](https://thanos.io/components/store.md/#index-cache).
+
 ## Configuration
 
 The following table lists the configurable parameters of the prometheus-thanos chart and their default values.

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -233,9 +233,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
 | `storeGateway.image.tag` | Docker image tag for store gateway | `v0.10.1` |
 | `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
-| `storeGateway.serviceAccount.create` | Create service account | `true` |
-| `storeGateway.serviceAccount.annotations` | Service account annotations | `nil` |
-| `storeGateway.indexCacheSize` | Index cache size | `500MB` |
+| `storeGateway.indexCache.config` | Config for the index cache, see [the docs](https://thanos.io/components/store.md/#index-cache) | `max_size: 500MB` |
+| `storeGateway.indexCache.type` | Type of the index cache, either `IN-MEMORY` or `MEMCACHED` | `IN-MEMORY` |
 | `storeGateway.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `storeGateway.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
 | `storeGateway.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
@@ -260,6 +259,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.readinessProbe.timeoutSeconds` |Readiness probe timeoutSeconds | `30` |
 | `storeGateway.replicaCount` | Replica count for store gateway | `1` |
 | `storeGateway.resources` | Resources | `{}` |
+| `storeGateway.serviceAccount.create` | Create service account | `true` |
+| `storeGateway.serviceAccount.annotations` | Service account annotations | `nil` |
 | `storeGateway.tolerations` | Tolerations | `[]` |
 | `storeGateway.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
 | `storeGateway.volumeMounts` | Additional volume mounts | `nil` |

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
@@ -44,7 +44,10 @@ spec:
           - store
           - --data-dir=/data
           - --log.level={{ .Values.storeGateway.logLevel }}
-          - --index-cache-size={{ .Values.storeGateway.indexCacheSize }}
+          - |
+            --index-cache.config=type: {{ .Values.storeGateway.indexCache.type }}
+            config:
+            {{- toYaml .Values.storeGateway.indexCache.config | nindent 14 }}
           - --chunk-pool-size={{ .Values.storeGateway.chunkPoolSize }}
           {{- range $key, $value := .Values.storeGateway.additionalFlags }}
           - --{{ $key }}{{if $value }}={{ $value }}{{end}}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -106,7 +106,11 @@ storeGateway:
   # - name: GOOGLE_APPLICATION_CREDENTIALS
   #   value: /etc/gcp/secrets/credentials.json
   logLevel: info
-  indexCacheSize: 500MB
+  # IndexCache configuraiton. See https://thanos.io/components/store.md/#index-cache for available options
+  indexCache:
+    type: IN-MEMORY
+    config:
+      max_size: 500MB
   chunkPoolSize: 500MB
 
   objStoreType: GCS  # WARNING: this is default to null in other sections


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Makes the index cache for the store gateway configurable. This now
supports the use of Memcached instead of local memory as the index cache
store (released in [Thanos 0.10.0](https://github.com/thanos-io/thanos/releases/tag/v0.10.0).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #289


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
