### PR TITLE
[prometheus-thanos] Fix compact and store-gateway templates breaking when there are no extra volumes defined

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.1"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 3.0.0
+version: 3.0.1
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -85,14 +85,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (.Values.compact.volumes) or (not .Values.compact.persistentVolume.enabled) }}
       volumes:
-        {{- toYaml .Values.compact.volumes | nindent 8 }}
+        {{- with .Values.compact.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if not .Values.compact.persistentVolume.enabled }}
         - name: storage-volume
           emptyDir: {}
         {{- end }}
-      {{- end }}
       {{- if .Values.compact.podNumericalPriorityEnabled }}
       priority: {{ .Values.compact.podPriority }}
       {{- else if .Values.compact.podPriorityClassName }}
@@ -108,7 +108,7 @@ spec:
         {{- end }}
       spec:
         accessModes:
-        {{ toYaml .Values.compact.persistentVolume.accessModes | nindent 10 }}
+        {{- toYaml .Values.compact.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.compact.persistentVolume.size }}"

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -77,46 +77,46 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.compact.affinity }}
+      {{- with .Values.compact.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.compact.tolerations }}
+      {{- end }}
+      {{- with .Values.compact.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.compact.volumes }}
+      {{- end }}
+      {{- with .Values.compact.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.compact.podNumericalPriorityEnabled }}
+      {{- end }}
+      {{- if .Values.compact.podNumericalPriorityEnabled }}
       priority: {{ .Values.compact.podPriority }}
-    {{- else if .Values.compact.podPriorityClassName }}
+      {{- else if .Values.compact.podPriorityClassName }}
       priorityClassName: {{ .Values.compact.podPriorityClassName }}
-    {{- end }}
-    {{- if .Values.compact.persistentVolume.enabled }}
+      {{- end }}
+  {{- if .Values.compact.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: storage-volume
         {{- if .Values.compact.persistentVolume.annotations }}
         annotations:
-{{ toYaml .Values.compact.persistentVolume.annotations | indent 10 }}
+        {{- toYaml .Values.compact.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-{{ toYaml .Values.compact.persistentVolume.accessModes | indent 10 }}
+        {{ toYaml .Values.compact.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.compact.persistentVolume.size }}"
-      {{- if .Values.compact.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.compact.persistentVolume.storageClass) }}
+        {{- if .Values.compact.persistentVolume.storageClass }}
+        {{- if (eq "-" .Values.compact.persistentVolume.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{- else }}
         storageClassName: "{{ .Values.compact.persistentVolume.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- else }}
+        {{- end }}
+        {{- end }}
+  {{- else }}
         - name: storage-volume
           emptyDir: {}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus-thanos/templates/compact-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compact-statefulset.yaml
@@ -85,9 +85,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.compact.volumes }}
+      {{- if (.Values.compact.volumes) or (not .Values.compact.persistentVolume.enabled) }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.compact.volumes | nindent 8 }}
+        {{- if not .Values.compact.persistentVolume.enabled }}
+        - name: storage-volume
+          emptyDir: {}
+        {{- end }}
       {{- end }}
       {{- if .Values.compact.podNumericalPriorityEnabled }}
       priority: {{ .Values.compact.podPriority }}
@@ -115,8 +119,5 @@ spec:
         storageClassName: "{{ .Values.compact.persistentVolume.storageClass }}"
         {{- end }}
         {{- end }}
-  {{- else }}
-        - name: storage-volume
-          emptyDir: {}
   {{- end }}
 {{- end }}

--- a/charts/prometheus-thanos/templates/ruler-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler-statefulset.yaml
@@ -24,14 +24,14 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         prometheus-thanos-peer: "true"
         {{- with .Values.ruler.additionalLabels }}
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10902"
         checksum/config: {{ include (print $.Template.BasePath "/ruler-configmap.yaml") . | sha256sum }}
         {{- with .Values.ruler.additionalAnnotations }}
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       serviceAccount: {{ include "prometheus-thanos.fullname" . }}-ruler
@@ -98,16 +98,16 @@ spec:
           resources:
             {{- toYaml .Values.ruler.resources | nindent 12 }}
           volumeMounts:
-            - mountPath: /etc/thanos-ruler
-              name: config
-            - mountPath: /etc/thanos-ruler/external
-              name: external-config-volume
-            - mountPath: /data
-              name: storage-volume
+          - mountPath: /etc/thanos-ruler
+            name: config
+          - mountPath: /etc/thanos-ruler/external
+            name: external-config-volume
+          - mountPath: /data
+            name: storage-volume
           {{- with .Values.ruler.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
-{{- if .Values.ruler.sidecar.enabled }}
+        {{- if .Values.ruler.sidecar.enabled }}
         - env:
           - name: LABEL
             value: {{ .Values.ruler.sidecar.watchLabel }}
@@ -134,56 +134,57 @@ spec:
           volumeMounts:
           - mountPath: /etc/config
             name: external-config-volume
-{{- end }}
+        {{- end }}
       {{- with .Values.ruler.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.ruler.affinity }}
+      {{- with .Values.ruler.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.ruler.tolerations }}
+      {{- end }}
+      {{- with .Values.ruler.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       volumes:
-        - name: external-config-volume
-          emptyDir: {}
-        - configMap:
-            name: {{ include "prometheus-thanos.fullname" . }}-ruler
-          name: config
-    {{- with .Values.ruler.volumes }}
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.ruler.podNumericalPriorityEnabled }}
+      - name: external-config-volume
+        emptyDir: {}
+      - configMap:
+          name: {{ include "prometheus-thanos.fullname" . }}-ruler
+        name: config
+      {{- with .Values.ruler.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if not .Values.ruler.persistentVolume.enabled }}
+      - name: storage-volume
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.ruler.podNumericalPriorityEnabled }}
       priority: {{ .Values.ruler.podPriority }}
-    {{- else if .Values.ruler.podPriorityClassName }}
+      {{- else if .Values.ruler.podPriorityClassName }}
       priorityClassName: {{ .Values.ruler.podPriorityClassName }}
-    {{- end }}
-{{- if .Values.ruler.persistentVolume.enabled }}
+      {{- end }}
+  {{- if .Values.ruler.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: storage-volume
         {{- if .Values.ruler.persistentVolume.annotations }}
         annotations:
-{{ toYaml .Values.ruler.persistentVolume.annotations | indent 10 }}
+          {{- toYaml .Values.ruler.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-{{ toYaml .Values.ruler.persistentVolume.accessModes | indent 10 }}
+          {{- toYaml .Values.ruler.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.ruler.persistentVolume.size }}"
-      {{- if .Values.ruler.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.ruler.persistentVolume.storageClass) }}
+        {{- if .Values.ruler.persistentVolume.storageClass }}
+        {{- if (eq "-" .Values.ruler.persistentVolume.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{- else }}
         storageClassName: "{{ .Values.ruler.persistentVolume.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- else }}
-        - name: storage-volume
-          emptyDir: {}
-{{- end }}
+        {{- end }}
+        {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway-statefulset.yaml
@@ -99,46 +99,47 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.storeGateway.affinity }}
+      {{- with .Values.storeGateway.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.storeGateway.tolerations }}
+      {{- end }}
+      {{- with .Values.storeGateway.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.storeGateway.volumes }}
+      {{- end }}
       volumes:
+        {{- with .Values.storeGateway.volumes }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.storeGateway.podNumericalPriorityEnabled }}
+        {{- end }}
+        {{- if not .Values.storeGateway.persistentVolume.enabled }}
+        - name: storage-volume
+          emptyDir: {}
+        {{- end }}
+      {{- if .Values.storeGateway.podNumericalPriorityEnabled }}
       priority: {{ .Values.storeGateway.podPriority }}
-    {{- else if .Values.storeGateway.podPriorityClassName }}
+      {{- else if .Values.storeGateway.podPriorityClassName }}
       priorityClassName: {{ .Values.storeGateway.podPriorityClassName }}
-    {{- end }}
-{{- if .Values.storeGateway.persistentVolume.enabled }}
+      {{- end }}
+  {{- if .Values.storeGateway.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: storage-volume
         {{- if .Values.storeGateway.persistentVolume.annotations }}
         annotations:
-{{ toYaml .Values.storeGateway.persistentVolume.annotations | indent 10 }}
+        {{- toYaml .Values.storeGateway.persistentVolume.annotations | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-{{ toYaml .Values.storeGateway.persistentVolume.accessModes | indent 10 }}
+        {{- toYaml .Values.storeGateway.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.storeGateway.persistentVolume.size }}"
-      {{- if .Values.storeGateway.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.storeGateway.persistentVolume.storageClass) }}
+        {{- if .Values.storeGateway.persistentVolume.storageClass }}
+        {{- if (eq "-" .Values.storeGateway.persistentVolume.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{- else }}
         storageClassName: "{{ .Values.storeGateway.persistentVolume.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- else }}
-        - name: storage-volume
-          emptyDir: {}
-{{- end }}
+        {{- end }}
+        {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The prometheus-thanos chart was breaking (producing invalid yaml) when installed with disabled `compact.persistentVolume` and no custom volumes (both are defaults).

#### Which issue this PR fixes
  - fixes #296
  - most probably also #255 

#### Special notes for your reviewer:

In `compact-statefulset.yaml`, I have:
- fixed indentation
- fixed the logic bug (see details in respective commit message)
- (**moving to separate PR**) improved readability by extracting `{{ $values := .Values.compact }}` at the top of template

I also noticed the same logic issue exists in `store-gateway-statefulset.yaml`, so I ported all the above fixes there as well.


#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
