### PR TITLE
[fluentd-elasticsearch] Fix Role for k8s >1.15

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 6.1.1
+version: 6.1.2
 appVersion: 2.8.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -10,7 +10,11 @@ metadata:
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
+{{- if semverCompare "> 1.15" .Capabilities.KubeVersion.GitVersion }}
+- apiGroups: ['policy']
+{{- else }}
 - apiGroups: ['extensions']
+{{- end }}
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix fluentd-elasticsearch Role for Kubernetes >1.15

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
