### PR TITLE
[fluentd-elasticsearch] Allow to switch output type.

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 6.1.2
+version: 6.1.3
 appVersion: 2.8.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -187,7 +187,7 @@ especially:
 - fix renamed fields in other places - such as Kibana or Grafana, in items
   such as dashboards queries/vars/annotations
 
-It is strongly suggested to set up temporarily new fluend instance with output 
+It is strongly suggested to set up temporarily new fluentd instance with output 
 to another elasticsearch index prefix to see the differences and then apply changes. The amount of fields altered can be noticeable and hard to list them all in this document.
 
 Some dashboards can be easily fixed with sed:

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.scheme`                       | Elasticsearch scheme setting                                                   | `http`                                 |
 | `elasticsearch.sslVerify`                    | Elasticsearch Auth SSL verify                                                  | `true`                                 |
 | `elasticsearch.sslVersion`                   | Elasticsearch tls version setting                                              | `TLSv1_2`                              |
+| `elasticsearch.outputType`                   | Elasticsearch output type                                                      | `elasticsearch`                        |
 | `elasticsearch.typeName`                     | Elasticsearch type name                                                        | `_doc`                                 |
 | `elasticsearch.logLevel`                     | Elasticsearch global log level                                                 | `info`                                 |
 | `env`                                        | List of env vars that are added to the fluentd pods                            | `{}`                                   |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -494,7 +494,7 @@ data:
     <label @NORMAL>
     <match **>
       @id elasticsearch
-      @type elasticsearch
+      @type "#{ENV['OUTPUT_TYPE']}"
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key true
       host "#{ENV['OUTPUT_HOST']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -98,6 +98,8 @@ spec:
           {{- else }}
           value: {{ .Values.elasticsearch.scheme | quote }}
           {{- end }}
+        - name: OUTPUT_TYPE
+          value: {{ .Values.elasticsearch.outputType | quote }}
         - name: OUTPUT_SSL_VERIFY
           value: {{ .Values.elasticsearch.sslVerify | quote }}
         - name: OUTPUT_SSL_VERSION

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -68,6 +68,7 @@ elasticsearch:
   scheme: "http"
   sslVerify: true
   sslVersion: "TLSv1_2"
+  outputType: "elasticsearch"
   typeName: "_doc"
   logLevel: "info"
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows to change `@type` in output section. This may be useful when `elasticsearch_dynamic` type is the desired way to ship the logs. Another part of this solution - "LOGSTASH_PREFIX" is already there

FTR please see this comment: https://github.com/kubernetes/kubernetes/issues/23001#issuecomment-462538401

#### Special notes for your reviewer:
@monotek  @axdotl I've tested it in my environment with:
```
elasticsearch:
  outputType: elasticsearch_dynamic
  logstashPrefix: "logstash-${record['kubernetes']['namespace_id']}"
```
Could we please get this merged?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://developercertificate.org) signed
- [ x ] Chart Version bumped (if the pr is an update to an existing chart)
- [ x ] Variables are documented in the README.md
- [ x ] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
