### PR TITLE
[fluentd-elasticsearch] Add default values for env and secrets

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 6.2.2
+version: 6.2.3
 appVersion: 3.0.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -80,19 +80,19 @@ fluentdArgs: "--no-supervisor -q"
 # If you want to add custom environment variables, use the env dict
 # You can then reference these in your config file e.g.:
 #     user "#{ENV['OUTPUT_USER']}"
-env:
+env: {}
   # OUTPUT_USER: my_user
   # LIVENESS_THRESHOLD_SECONDS: 300
   # STUCK_THRESHOLD_SECONDS: 900
 
 # If you want to add custom environment variables from secrets, use the secret list
-secret:
+secret: []
 # - name: ELASTICSEARCH_PASSWORD
 #   secret_name: elasticsearch
 #   secret_key: password
 
 # If you want to add plugins at start time
-additionalPlugins:
+additionalPlugins: []
 # - name: fluent-plugin-s3
 #   version: 1.1.11
 


### PR DESCRIPTION
Signed-off-by: Jared Burns <jared.burns@nike.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds a default value to the `env` config variable of the fluentd-elasticsearch chart, which allows this chart to be templated using the helm 3 client.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #310 


#### Special notes for your reviewer:

I also added a default value for `secret` in this PR. It isn't strictly required, but it a best practice.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
