### PR TITLE
[fluentd-elasticsearch] Fix jobLabel in ServiceMonitor

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 6.2.3
+version: 6.2.4
 appVersion: 3.0.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -121,6 +121,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `serviceMonitor.labels`                      | Optional labels for serviceMonitor                                             | `{}`                                   |
 | `serviceMonitor.metricRelabelings`           | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                   |
 | `serviceMonitor.relabelings`                 | Optional relabel configs to apply to samples before scraping                   | `[]`                                   |
+| `serviceMonitor.jobLabel`                    | Label whose value will define the job name                                     | `app.kubernetes.io/instance`           |
 | `serviceMonitor.type`                        | Optional the type of the metrics service                                       | `ClusterIP`                            |
 | `tolerations`                                | Optional daemonset tolerations                                                 | `[]`                                   |
 | `updateStrategy`                             | Optional daemonset update strategy                                             | `type: RollingUpdate`                  |

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -26,7 +26,7 @@ spec:
     relabelings:
     {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
     {{- end }}
-  jobLabel: "{{ .Release.Name }}"
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "fluentd-elasticsearch.name" . }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -200,6 +200,7 @@ serviceMonitor:
   labels: {}
   metricRelabelings: []
   relabelings: []
+  jobLabel: "app.kubernetes.io/instance"
   type: ClusterIP
 
 serviceMetric:


### PR DESCRIPTION
#### What this PR does / why we need it:

The value of `jobLabel` in a `ServiceMonitor` defines the label of the scraped service whose value should be used as `job_name` by Prometheus. However, it looks like in the chart it was being used as if it was meant to be the actual value one wanted to use for the job. Because of
this, scraped metrics would end up with, say, `fluentd-elasticsearch-metrics` (the name of the scraped `Service`) instead of `fluentd-elasticsearch`.

This is particularly tricky since it would interact badly with the provided `PrometheusRules`. For example, `FluentdNodeDown`, that would normally be triggered when there are no fluentd pods running, gets defined as `up{job="fluentd-elasticsearch"} == 0`, but because there are no
samples generated for that job, it remains forever green!

We now use `app.kubernetes.io/instance` as `jobLabel` and make it overridable in the `Values.yaml`.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
