### PR TITLE
[prometheus-thanos] Allow annotations on services

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.11.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.0.2
+version: 4.1.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -233,15 +233,19 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.volumes` | Additional volumes | `nil` |
 | `service.bucketWebInterface.type` | Service type for the bucket web interface | `ClusterIP` |
 | `service.bucketWebInterface.http.port` | Service http port for the bucket web interface  | `9090` |
+| `service.bucketWebInterface.annotations` | Service annotations for the bucket web interface  | `{}` |
 | `service.querier.type` | Service type for the querier | `ClusterIP` |
 | `service.querier.http.port` | Service http port for the querier  | `9090` |
 | `service.querier.grpc.port` | Service grpc port for the querier  | `10901` |
+| `service.querier.annotations` | Service annotations for the querier  | `{}` |
 | `service.storeGateway.type` | Service type for the store gateway | `ClusterIP` |
 | `service.storeGateway.http.port` | Service http port for the store gateway | `9090` |
 | `service.storeGateway.grpc.port` | Service grpc port for the store gateway | `10901` |
+| `service.storeGateway.annotations` | Service annotations for the store gateway | `{}` |
 | `service.ruler.type` | Service type for ruler | `ClusterIP` |
 | `service.ruler.http.port` | Service http port for ruler | `9090` |
 | `service.ruler.grpc.port` | Service grpc port for ruler | `10901` |
+| `service.ruler.annotations` | Service annotations for the ruler | `{}` |
 | `storeGateway.enabled` | Controls whether StoreGateway related resources should be created | `true` |
 | `storeGateway.affinity` | Affinity | `{}` |
 | `storeGateway.additionalAnnotations` | Additional annotations on store gateway pods| `{}` |

--- a/charts/prometheus-thanos/templates/bucket-web/service.yaml
+++ b/charts/prometheus-thanos/templates/bucket-web/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-bucket-web-interface
+{{- if .Values.service.bucketWebInterface.annotations }}
+  annotations:
+{{ toYaml .Values.service.bucketWebInterface.annotations | indent 4 }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-bucket-web-interface
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}

--- a/charts/prometheus-thanos/templates/querier/service.yaml
+++ b/charts/prometheus-thanos/templates/querier/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-querier
+{{- if .Values.service.querier.annotations }}
+  annotations:
+{{ toYaml .Values.service.querier.annotations | indent 4 }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-querier
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}

--- a/charts/prometheus-thanos/templates/ruler/service.yaml
+++ b/charts/prometheus-thanos/templates/ruler/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-ruler
+{{- if .Values.service.ruler.annotations }}
+  annotations:
+{{ toYaml .Values.service.ruler.annotations | indent 4 }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-ruler
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}

--- a/charts/prometheus-thanos/templates/store-gateway/service.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-store-gateway
+{{- if .Values.service.storeGateway.annotations }}
+  annotations:
+{{ toYaml .Values.service.storeGateway.annotations | indent 4 }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-store-gateway
     helm.sh/chart: {{ include "prometheus-thanos.chart" . }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -12,22 +12,26 @@ service:
       port: 9090
     grpc:
       port: 10901
+    annotations: {}
   storeGateway:
     type: ClusterIP
     http:
       port: 9090
     grpc:
       port: 10901
+    annotations: {}
   ruler:
     type: ClusterIP
     http:
       port: 9090
     grpc:
       port: 10901
+    annotations: {}
   bucketWebInterface:
     type: ClusterIP
     http:
       port: 9090
+    annotations: {}
 
 querier:
   enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds the ability to give custom annotations to services. In our use case this helps change the `alb.ingress.kubernetes.io/healthcheck-path` to support a 302 provided by the querier.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
