### PR TITLE
[prometheus-thanos] Allow the use of binary index headers

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.11.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.1.0
+version: 4.2.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -255,6 +255,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.autoscaling.maxReplicas` | Maximum number of replicas to scale to | `10` |
 | `storeGateway.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
 | `storeGateway.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
+| `storeGateway.binaryIndexHeader.enabled` | Whether or not to enable [binary index headers](https://thanos.io/proposals/201912_thanos_binary_index_header.md/) | `false` |
 | `storeGateway.chunkPoolSize` | Chunk pool size | `500MB` |
 | `storeGateway.extraEnv` | Extra env vars | `nil` |
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |

--- a/charts/prometheus-thanos/templates/store-gateway/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway/statefulset.yaml
@@ -60,6 +60,9 @@ spec:
           {{ else if .Values.storeGateway.objStoreConfigFile }}
           - --objstore.config-file={{ .Values.storeGateway.objStoreConfigFile }}
           {{- end }}
+          {{- if .Values.storeGateway.binaryIndexHeader.enabled -}}
+          - --experimental.enable-index-header
+          {{- end -}}
           ports:
             - name: http
               containerPort: 10902

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -116,6 +116,8 @@ storeGateway:
     config:
       max_size: 500MB
   chunkPoolSize: 500MB
+  binaryIndexHeader:
+    enabled: false
 
   objStoreType: GCS  # WARNING: this is default to null in other sections
   additionalFlags: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds a flag that allows opting in to using binary index headers (as
released in Thanos v0.11.0). The feature is still experimental.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #316


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
