### PR TITLE
serviceAccountName for DaemonSet fix

### DIFF
--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      serviceAccountName: {{ include "fluentd-elasticsearch.fullname" . }}
+      serviceAccountName: {{ if .Values.serviceAccount.name }}{{ .Values.serviceAccount.name }}{{ else }}{{ include "fluentd-elasticsearch.fullname" . }}{{ end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR fixes serviceAccountName for DaemonSet and makes it aligned with the service account name in case it does not default.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [ ] Chart Version bumped (if the pr is an update to an existing chart)
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
