### PR TITLE
[fluentd-elasticsearch] Add support for setting the awsSigningSidecar's remote read timeout

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 6.2.4
+version: 6.3.0
 appVersion: 3.0.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -42,90 +42,91 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd elasticsearch chart and their default values.
 
-| Parameter                                    | Description                                                                    | Default                                |
-| -------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------- |
-| `affinity`                                   | Optional daemonset affinity                                                    | `{}`                                   |
-| `annotations`                                | Optional daemonset annotations                                                 | `NULL`                                 |
-| `podAnnotations`                             | Optional daemonset's pods annotations                                          | `NULL`                                 |
-| `configMaps.useDefaults.systemConf`          | Use default system.conf                                                        | true                                   |
-| `configMaps.useDefaults.containersInputConf` | Use default containers.input.conf                                              | true                                   |
-| `configMaps.useDefaults.systemInputConf`     | Use default system.input.conf                                                  | true                                   |
-| `configMaps.useDefaults.forwardInputConf`    | Use default forward.input.conf                                                 | true                                   |
-| `configMaps.useDefaults.monitoringConf`      | Use default monitoring.conf                                                    | true                                   |
-| `configMaps.useDefaults.outputConf`          | Use default output.conf                                                        | true                                   |
-| `extraConfigMaps`                            | Add additional Configmap or overwrite disabled default                         | `{}`                                   |
-| `awsSigningSidecar.enabled`                  | Enable AWS request signing sidecar                                             | `false`                                |
-| `awsSigningSidecar.resources`                | AWS Sidecar resources                                                          | `{}`                                   |
-| `awsSigningSidecar.network.port`             | AWS Sidecar exposure port                                                      | `8080`                                 |
-| `awsSigningSidecar.network.address`          | AWS Sidecar listen address                                                     | `localhost`                            |
-| `awsSigningSidecar.image.repository`         | AWS signing sidecar repository image                                           | `abutaha/aws-es-proxy`                 |
-| `awsSigningSidecar.image.tag`                | AWS signing sidecar repository tag                                             | `0.9`                                  |
-| `elasticsearch.auth.enabled`                 | Elasticsearch Auth enabled                                                     | `false`                                |
-| `elasticsearch.auth.user`                    | Elasticsearch Auth User                                                        | `""`                                   |
-| `elasticsearch.auth.password`                | Elasticsearch Auth Password                                                    | `""`                                   |
-| `elasticsearch.bufferChunkLimit`             | Elasticsearch buffer chunk limit                                               | `2M`                                   |
-| `elasticsearch.bufferQueueLimit`             | Elasticsearch buffer queue limit                                               | `8`                                    |
-| `elasticsearch.host`                         | Elasticsearch Host                                                             | `elasticsearch-client`                 |
-| `elasticsearch.logstashPrefix`               | Elasticsearch Logstash prefix                                                  | `logstash`                             |
-| `elasticsearch.port`                         | Elasticsearch Port                                                             | `9200`                                 |
-| `elasticsearch.path`                         | Elasticsearch Path                                                             | `""`                                   |
-| `elasticsearch.scheme`                       | Elasticsearch scheme setting                                                   | `http`                                 |
-| `elasticsearch.sslVerify`                    | Elasticsearch Auth SSL verify                                                  | `true`                                 |
-| `elasticsearch.sslVersion`                   | Elasticsearch tls version setting                                              | `TLSv1_2`                              |
-| `elasticsearch.outputType`                   | Elasticsearch output type                                                      | `elasticsearch`                        |
-| `elasticsearch.typeName`                     | Elasticsearch type name                                                        | `_doc`                                 |
-| `elasticsearch.logLevel`                     | Elasticsearch global log level                                                 | `info`                                 |
-| `env`                                        | List of env vars that are added to the fluentd pods                            | `{}`                                   |
-| `fluentdArgs`                                | Fluentd args                                                                   | `--no-supervisor -q`                   |
-| `secret`                                     | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
-| `extraVolumeMounts`                          | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                   |
-| `extraVolume`                                | Extra volume                                                                   | `[]`                                   |
-| `hostLogDir.varLog`                          | Specify where fluentd can find var log                                         | `/var/log`                             |
-| `hostLogDir.dockerContainers`                | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`           |
-| `hostLogDir.libSystemdDir`                   | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                           |
-| `image.repository`                           | Image                                                                          | `quay.io/fluentd_elasticsearch/fluentd`|
-| `image.tag`                                  | Image tag                                                                      | `v3.0.0`                               |
-| `image.pullPolicy`                           | Image pull policy                                                              | `IfNotPresent`                         |
-| `image.pullSecrets`                          | Image pull secrets                                                             | ``                                     |
-| `livenessProbe.enabled`                      | Whether to enable livenessProbe                                                | `true`                                 |
-| `livenessProbe.initialDelaySeconds`          | livenessProbe initial delay seconds                                            | `600`                                  |
-| `livenessProbe.periodSeconds`                | livenessProbe period seconds                                                   | `60`                                   |
-| `livenessProbe.kind`                         | livenessProbe kind                                                             | `Set to a Linux compatible command`    |
-| `nodeSelector`                               | Optional daemonset nodeSelector                                                | `{}`                                   |
-| `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                             | `{}`                                   |
-| `podSecurityPolicy.enabled`                  | Specify if a pod security policy must be created                               | `false`                                |
-| `priorityClassName`                          | Optional PriorityClass for pods                                                | `""`                                   |
-| `prometheusRule.enabled`                     | Whether to enable Prometheus prometheusRule                                    | `false`                                |
-| `prometheusRule.prometheusNamespace`         | Namespace for prometheusRule                                                   | `monitoring`                           |
-| `prometheusRule.labels`                      | Optional labels for prometheusRule                                             | `{}`                                   |
-| `rbac.create`                                | RBAC                                                                           | `true`                                 |
-| `resources.limits.cpu`                       | CPU limit                                                                      | `100m`                                 |
-| `resources.limits.memory`                    | Memory limit                                                                   | `500Mi`                                |
-| `resources.requests.cpu`                     | CPU request                                                                    | `100m`                                 |
-| `resources.requests.memory`                  | Memory request                                                                 | `200Mi`                                |
-| `service`                                    | Service definition                                                             | `{}`                                   |
-| `service.ports`                              | List of service ports dict [{name:...}...]                                     | Not Set                                |
-| `service.ports[].type`                       | Service type (ClusterIP/NodePort)                                              | `ClusterIP`                            |
-| `service.ports[].name`                       | One of service ports name                                                      | Not Set                                |
-| `service.ports[].port`                       | Service port                                                                   | Not Set                                |
-| `service.ports[].nodePort`                   | NodePort port (when service.type is NodePort)                                  | Not Set                                |
-| `service.ports[].protocol`                   | Service protocol(optional, can be TCP/UDP)                                     | Not Set                                |
-| `serviceAccount.create`                      | Specifies whether a service account should be created.                         | `true`                                 |
-| `serviceAccount.name`                        | Name of the service account.                                                   | `""`                                   |
-| `serviceAccount.annotations`                 | Specify annotations in the pod service account                                 | `{}`                                   |
-| `serviceMetric.enabled`                      | Generate the metric service regardless of whether serviceMonitor is enabled.   | `false`                                |
-| `serviceMonitor.enabled`                     | Whether to enable Prometheus serviceMonitor                                    | `false`                                |
-| `serviceMonitor.port`                        | Define on which port the ServiceMonitor should scrape                          | `24231`                                |
-| `serviceMonitor.interval`                    | Interval at which metrics should be scraped                                    | `10s`                                  |
-| `serviceMonitor.path`                        | Path for Metrics                                                               | `/metrics`                             |
-| `serviceMonitor.labels`                      | Optional labels for serviceMonitor                                             | `{}`                                   |
-| `serviceMonitor.metricRelabelings`           | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                   |
-| `serviceMonitor.relabelings`                 | Optional relabel configs to apply to samples before scraping                   | `[]`                                   |
-| `serviceMonitor.jobLabel`                    | Label whose value will define the job name                                     | `app.kubernetes.io/instance`           |
-| `serviceMonitor.type`                        | Optional the type of the metrics service                                       | `ClusterIP`                            |
-| `tolerations`                                | Optional daemonset tolerations                                                 | `[]`                                   |
-| `updateStrategy`                             | Optional daemonset update strategy                                             | `type: RollingUpdate`                  |
-| `additionalPlugins`                          | Optional additionnal plugins to install when pod starts                        | `{}`                                   |
+| Parameter                                            | Description                                                                    | Default                                |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------- |
+| `affinity`                                           | Optional daemonset affinity                                                    | `{}`                                   |
+| `annotations`                                        | Optional daemonset annotations                                                 | `NULL`                                 |
+| `podAnnotations`                                     | Optional daemonset's pods annotations                                          | `NULL`                                 |
+| `configMaps.useDefaults.systemConf`                  | Use default system.conf                                                        | true                                   |
+| `configMaps.useDefaults.containersInputConf`         | Use default containers.input.conf                                              | true                                   |
+| `configMaps.useDefaults.systemInputConf`             | Use default system.input.conf                                                  | true                                   |
+| `configMaps.useDefaults.forwardInputConf`            | Use default forward.input.conf                                                 | true                                   |
+| `configMaps.useDefaults.monitoringConf`              | Use default monitoring.conf                                                    | true                                   |
+| `configMaps.useDefaults.outputConf`                  | Use default output.conf                                                        | true                                   |
+| `extraConfigMaps`                                    | Add additional Configmap or overwrite disabled default                         | `{}`                                   |
+| `awsSigningSidecar.enabled`                          | Enable AWS request signing sidecar                                             | `false`                                |
+| `awsSigningSidecar.resources`                        | AWS Sidecar resources                                                          | `{}`                                   |
+| `awsSigningSidecar.network.port`                     | AWS Sidecar exposure port                                                      | `8080`                                 |
+| `awsSigningSidecar.network.address`                  | AWS Sidecar listen address                                                     | `localhost`                            |
+| `awsSigningSidecar.network.remoteReadTimeoutSeconds` | AWS Sidecar socket read timeout when talking to ElasticSearch                  | `15`                                   |
+| `awsSigningSidecar.image.repository`                 | AWS signing sidecar repository image                                           | `abutaha/aws-es-proxy`                 |
+| `awsSigningSidecar.image.tag`                        | AWS signing sidecar repository tag                                             | `v1.0`                                 |
+| `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                |
+| `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                   |
+| `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                   |
+| `elasticsearch.bufferChunkLimit`                     | Elasticsearch buffer chunk limit                                               | `2M`                                   |
+| `elasticsearch.bufferQueueLimit`                     | Elasticsearch buffer queue limit                                               | `8`                                    |
+| `elasticsearch.host`                                 | Elasticsearch Host                                                             | `elasticsearch-client`                 |
+| `elasticsearch.logstashPrefix`                       | Elasticsearch Logstash prefix                                                  | `logstash`                             |
+| `elasticsearch.port`                                 | Elasticsearch Port                                                             | `9200`                                 |
+| `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                   |
+| `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                 |
+| `elasticsearch.sslVerify`                            | Elasticsearch Auth SSL verify                                                  | `true`                                 |
+| `elasticsearch.sslVersion`                           | Elasticsearch tls version setting                                              | `TLSv1_2`                              |
+| `elasticsearch.outputType`                           | Elasticsearch output type                                                      | `elasticsearch`                        |
+| `elasticsearch.typeName`                             | Elasticsearch type name                                                        | `_doc`                                 |
+| `elasticsearch.logLevel`                             | Elasticsearch global log level                                                 | `info`                                 |
+| `env`                                                | List of env vars that are added to the fluentd pods                            | `{}`                                   |
+| `fluentdArgs`                                        | Fluentd args                                                                   | `--no-supervisor -q`                   |
+| `secret`                                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
+| `extraVolumeMounts`                                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                   |
+| `extraVolume`                                        | Extra volume                                                                   | `[]`                                   |
+| `hostLogDir.varLog`                                  | Specify where fluentd can find var log                                         | `/var/log`                             |
+| `hostLogDir.dockerContainers`                        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`           |
+| `hostLogDir.libSystemdDir`                           | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                           |
+| `image.repository`                                   | Image                                                                          | `quay.io/fluentd_elasticsearch/fluentd`|
+| `image.tag`                                          | Image tag                                                                      | `v3.0.0`                               |
+| `image.pullPolicy`                                   | Image pull policy                                                              | `IfNotPresent`                         |
+| `image.pullSecrets`                                  | Image pull secrets                                                             | ``                                     |
+| `livenessProbe.enabled`                              | Whether to enable livenessProbe                                                | `true`                                 |
+| `livenessProbe.initialDelaySeconds`                  | livenessProbe initial delay seconds                                            | `600`                                  |
+| `livenessProbe.periodSeconds`                        | livenessProbe period seconds                                                   | `60`                                   |
+| `livenessProbe.kind`                                 | livenessProbe kind                                                             | `Set to a Linux compatible command`    |
+| `nodeSelector`                                       | Optional daemonset nodeSelector                                                | `{}`                                   |
+| `podSecurityPolicy.annotations`                      | Specify pod annotations in the pod security policy                             | `{}`                                   |
+| `podSecurityPolicy.enabled`                          | Specify if a pod security policy must be created                               | `false`                                |
+| `priorityClassName`                                  | Optional PriorityClass for pods                                                | `""`                                   |
+| `prometheusRule.enabled`                             | Whether to enable Prometheus prometheusRule                                    | `false`                                |
+| `prometheusRule.prometheusNamespace`                 | Namespace for prometheusRule                                                   | `monitoring`                           |
+| `prometheusRule.labels`                              | Optional labels for prometheusRule                                             | `{}`                                   |
+| `rbac.create`                                        | RBAC                                                                           | `true`                                 |
+| `resources.limits.cpu`                               | CPU limit                                                                      | `100m`                                 |
+| `resources.limits.memory`                            | Memory limit                                                                   | `500Mi`                                |
+| `resources.requests.cpu`                             | CPU request                                                                    | `100m`                                 |
+| `resources.requests.memory`                          | Memory request                                                                 | `200Mi`                                |
+| `service`                                            | Service definition                                                             | `{}`                                   |
+| `service.ports`                                      | List of service ports dict [{name:...}...]                                     | Not Set                                |
+| `service.ports[].type`                               | Service type (ClusterIP/NodePort)                                              | `ClusterIP`                            |
+| `service.ports[].name`                               | One of service ports name                                                      | Not Set                                |
+| `service.ports[].port`                               | Service port                                                                   | Not Set                                |
+| `service.ports[].nodePort`                           | NodePort port (when service.type is NodePort)                                  | Not Set                                |
+| `service.ports[].protocol`                           | Service protocol(optional, can be TCP/UDP)                                     | Not Set                                |
+| `serviceAccount.create`                              | Specifies whether a service account should be created.                         | `true`                                 |
+| `serviceAccount.name`                                | Name of the service account.                                                   | `""`                                   |
+| `serviceAccount.annotations`                         | Specify annotations in the pod service account                                 | `{}`                                   |
+| `serviceMetric.enabled`                              | Generate the metric service regardless of whether serviceMonitor is enabled.   | `false`                                |
+| `serviceMonitor.enabled`                             | Whether to enable Prometheus serviceMonitor                                    | `false`                                |
+| `serviceMonitor.port`                                | Define on which port the ServiceMonitor should scrape                          | `24231`                                |
+| `serviceMonitor.interval`                            | Interval at which metrics should be scraped                                    | `10s`                                  |
+| `serviceMonitor.path`                                | Path for Metrics                                                               | `/metrics`                             |
+| `serviceMonitor.labels`                              | Optional labels for serviceMonitor                                             | `{}`                                   |
+| `serviceMonitor.metricRelabelings`                   | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                   |
+| `serviceMonitor.relabelings`                         | Optional relabel configs to apply to samples before scraping                   | `[]`                                   |
+| `serviceMonitor.jobLabel`                            | Label whose value will define the job name                                     | `app.kubernetes.io/instance`           |
+| `serviceMonitor.type`                                | Optional the type of the metrics service                                       | `ClusterIP`                            |
+| `tolerations`                                        | Optional daemonset tolerations                                                 | `[]`                                   |
+| `updateStrategy`                                     | Optional daemonset update strategy                                             | `type: RollingUpdate`                  |
+| `additionalPlugins`                                  | Optional additionnal plugins to install when pod starts                        | `{}`                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -166,7 +166,8 @@ spec:
         image: {{ .Values.awsSigningSidecar.image.repository }}:{{ .Values.awsSigningSidecar.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         args: ["-endpoint", "{{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}",
-               "-listen",   "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"]
+               "-listen",   "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}",
+               "-timeout",  "{{ .Values.awsSigningSidecar.network.remoteReadTimeoutSeconds }}"]
         env:
         - name: PORT_NUM
           value: {{ .Values.awsSigningSidecar.network.port | quote }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -27,9 +27,10 @@ awsSigningSidecar:
   network:
     port: 8080
     address: localhost
+    remoteReadTimeoutSeconds: 15
   image:
     repository: abutaha/aws-es-proxy
-    tag: 0.9
+    tag: v1.0
 
 # Specify to use specific priorityClass for pods
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add's support for setting the awsSigningSidecar's remote read timeout, as added in the `1.0` release of `aws-es-proxy` (which this PR upgrades to)

https://github.com/abutaha/aws-es-proxy/releases/tag/v1.0

Previously the default seemed to be taken from GoLang|OS; leading to ~15 minute downtime if connections to ElasticSearch are terminated/dropped on the remote side; e.g during an AWS ElasticSearch domain upgrade.

The default value chosen in the chart here is the same as the default in the `aws-es-proxy` [code](https://github.com/abutaha/aws-es-proxy/blob/4306126ddc375b65d26d1d85b3e08e8f8532641e/aws-es-proxy.go#L438) (15 seconds).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)