### PR TITLE
[fluentd-elasticsearch] Allow multiple hosts in config

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 7.0.0
+version: 8.0.0
 appVersion: 3.0.0
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -66,9 +66,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                   |
 | `elasticsearch.bufferChunkLimit`                     | Elasticsearch buffer chunk limit                                               | `2M`                                   |
 | `elasticsearch.bufferQueueLimit`                     | Elasticsearch buffer queue limit                                               | `8`                                    |
-| `elasticsearch.host`                                 | Elasticsearch Host                                                             | `elasticsearch-client`                 |
+| `elasticsearch.hosts`                                | Elasticsearch Host List                                                        | `["elasticsearch-client:9200"]`        |
 | `elasticsearch.logstashPrefix`                       | Elasticsearch Logstash prefix                                                  | `logstash`                             |
-| `elasticsearch.port`                                 | Elasticsearch Port                                                             | `9200`                                 |
 | `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                   |
 | `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                 |
 | `elasticsearch.sslVerify`                            | Elasticsearch Auth SSL verify                                                  | `true`                                 |
@@ -237,3 +236,29 @@ UNIT
 ### From a version <= 6.3.0 to version => 7.0.0
 
 The additional plugins option has been removed as the used container image does not longer contains the build tools needed to build the plugins. Please use an own container image containing the plugins you want to use.
+
+### From a version < 8.0.0 to version => 8.0.0
+
+You can now [configure multiple elasticsearch hosts](https://docs.fluentd.org/output/elasticsearch#hosts-optional) as target for fluentd.
+
+The following parameters are deprecated and will be replaced by `elasticsearch.hosts` with a default value of `["elasticsearch-client:9200"]`
+```yaml
+elasticsearch:
+  host: elasticsearch-client
+  port: 9200
+```
+
+You can use any yaml array syntax:
+```yaml
+elasticsearch:
+  hosts: ["elasticsearch-node-1:9200", "elasticsearch-node-2:9200"]
+```
+```yaml
+elasticsearch:
+  hosts:
+    - "elasticsearch-node-1:9200"
+    - "elasticsearch-node-2:9200"
+```
+
+Note:
+> If you are using the AWS Sidecar, only the first host in the array is used. [Aws-es-proxy](https://github.com/abutaha/aws-es-proxy) is limited to one endpoint.

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                   |
 | `elasticsearch.bufferChunkLimit`                     | Elasticsearch buffer chunk limit                                               | `2M`                                   |
 | `elasticsearch.bufferQueueLimit`                     | Elasticsearch buffer queue limit                                               | `8`                                    |
-| `elasticsearch.hosts`                                | Elasticsearch Host List                                                        | `["elasticsearch-client:9200"]`        |
+| `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`        |
 | `elasticsearch.logstashPrefix`                       | Elasticsearch Logstash prefix                                                  | `logstash`                             |
 | `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                   |
 | `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                 |
@@ -238,6 +238,8 @@ UNIT
 The additional plugins option has been removed as the used container image does not longer contains the build tools needed to build the plugins. Please use an own container image containing the plugins you want to use.
 
 ### From a version < 8.0.0 to version => 8.0.0
+
+> Both `elasticsearch.host` and `elasticsearch.port` are removed in favor of `elasticsearch.hosts`
 
 You can now [configure multiple elasticsearch hosts](https://docs.fluentd.org/output/elasticsearch#hosts-optional) as target for fluentd.
 

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -497,6 +497,7 @@ data:
       @type "#{ENV['OUTPUT_TYPE']}"
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key true
+      hosts "#{ENV['OUTPUT_HOSTS']}"
       host "#{ENV['OUTPUT_HOST']}"
       port "#{ENV['OUTPUT_PORT']}"
       path "#{ENV['OUTPUT_PATH']}"

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -498,8 +498,6 @@ data:
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key true
       hosts "#{ENV['OUTPUT_HOSTS']}"
-      host "#{ENV['OUTPUT_HOST']}"
-      port "#{ENV['OUTPUT_PORT']}"
       path "#{ENV['OUTPUT_PATH']}"
       scheme "#{ENV['OUTPUT_SCHEME']}"
       ssl_verify "#{ENV['OUTPUT_SSL_VERIFY']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -57,19 +57,11 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: {{ .Values.fluentdArgs | quote }}
-        - name: OUTPUT_HOST
-          {{- if .Values.awsSigningSidecar.enabled }}
-          value: {{ .Values.awsSigningSidecar.network.address | quote }}
-          {{- else }}
-          value: {{ .Values.elasticsearch.host | quote }}
-          {{- end }}
         - name: OUTPUT_HOSTS
-          value: "{{- join "," .Values.elasticsearch.hosts }}"
-        - name: OUTPUT_PORT
           {{- if .Values.awsSigningSidecar.enabled }}
-          value: {{ .Values.awsSigningSidecar.network.port | quote }}
+          value: "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"
           {{- else }}
-          value: {{ .Values.elasticsearch.port | quote }}
+          value: "{{- join "," .Values.elasticsearch.hosts }}"
           {{- end }}
         - name: OUTPUT_PATH
           value: {{ .Values.elasticsearch.path | quote }}
@@ -156,7 +148,7 @@ spec:
       - name: {{ include "fluentd-elasticsearch.fullname" . }}-aws-es-proxy
         image: {{ .Values.awsSigningSidecar.image.repository }}:{{ .Values.awsSigningSidecar.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        args: ["-endpoint", "{{ .Values.elasticsearch.scheme }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}",
+        args: ["-endpoint", "{{ .Values.elasticsearch.scheme }}://{{ index .Values.elasticsearch.hosts 0 }}",
                "-listen",   "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}",
                "-timeout",  "{{ .Values.awsSigningSidecar.network.remoteReadTimeoutSeconds }}"]
         env:

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -63,6 +63,8 @@ spec:
           {{- else }}
           value: {{ .Values.elasticsearch.host | quote }}
           {{- end }}
+        - name: OUTPUT_HOSTS
+          value: "{{- join "," .Values.elasticsearch.hosts }}"
         - name: OUTPUT_PORT
           {{- if .Values.awsSigningSidecar.enabled }}
           value: {{ .Values.awsSigningSidecar.network.port | quote }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -62,7 +62,8 @@ elasticsearch:
     password: "yourPass"
   bufferChunkLimit: "2M"
   bufferQueueLimit: 8
-  host: "elasticsearch-client"
+  #host: "elasticsearch-client"
+  hosts: ["elasticsearch-node-1:9200", "elasticsearch-node-2:9200"]
   logstashPrefix: "logstash"
   port: 9200
   path: ""

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -62,10 +62,8 @@ elasticsearch:
     password: "yourPass"
   bufferChunkLimit: "2M"
   bufferQueueLimit: 8
-  #host: "elasticsearch-client"
-  hosts: ["elasticsearch-node-1:9200", "elasticsearch-node-2:9200"]
+  hosts: ["elasticsearch-client:9200"]
   logstashPrefix: "logstash"
-  port: 9200
   path: ""
   scheme: "http"
   sslVerify: true


### PR DESCRIPTION
@axdotl  
@monotek  

#### What this PR does / why we need it:

Since Fluentd config [accepts multiple hosts](https://docs.fluentd.org/output/elasticsearch#hosts-optional) in its config, I would like to be able to provide them through the chart. The new `hosts` array parameter allow for multiple elasticsearch hosts to be configured as target.

Deprecated both parameters 
```yaml
elasticsearch:
  host: elasticsearch-client
  port: 9200
```
in favor of 
```yaml
elasticsearch:
  hosts: ["elasticsearch-client:9200"]
```

If you are using the AWS Sidecar, only the first host in the array is used. [Aws-es-proxy](https://github.com/abutaha/aws-es-proxy) is limited to one endpoint.

#### Which issue this PR fixes
  - fixes #330

#### Special notes for your reviewer:
I could not test changes done to the aws-es-proxy sidecar, if someone can help me with that part

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
