### PR TITLE
graphite - expose carbon UDP port

### DIFF
--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.1.5-4"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.1
+version: 0.6.0
 appVersion: "1.1.5-4"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/templates/service.yaml
+++ b/charts/graphite/templates/service.yaml
@@ -23,6 +23,9 @@ spec:
     - name: graphite-plain
       port: 2003
       protocol: TCP
+    - name: graphite-udp
+      port: 2003
+      protocol: UDP
     - name: graphite-gui
       port: {{ .Values.service.port }}
       protocol: TCP

--- a/charts/graphite/templates/statefulset.yaml
+++ b/charts/graphite/templates/statefulset.yaml
@@ -33,6 +33,9 @@ spec:
           containerPort: {{ .Values.service.port }}
         - name: graphite-plain
           containerPort: 2003
+        - name: graphite-udp
+          containerPort: 2003
+          protocol: UDP
         - name: graphite-pickle
           containerPort: 2004
         - name: aggregate-plain


### PR DESCRIPTION
Added missing UDP port for plain carbon interface on port 2003 in statefullset and services. This UDP interface needs to be enabled by setting option 

ENABLE_UDP_LISTENER = True

in carbon.conf in the values.yaml.

It is still one of the best interfaces for pushing bulk amounts of metrics in, if you don't care about guaranteed delivery.

I tested the modifications in my own cluster and it works fine. Also, can still telnet to 2003 TCP port.

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
