### PR TITLE
[fluentd-elasticsearch] Adding new configurations for elasticsearch plugin

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 8.0.1
+version: 8.0.2
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 8.0.2
+version: 9.0.0
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -279,3 +279,28 @@ elasticsearch:
 
 Note:
 > If you are using the AWS Sidecar, only the first host in the array is used. [Aws-es-proxy](https://github.com/abutaha/aws-es-proxy) is limited to one endpoint.
+
+### From a version < 8.0.0 to version => 9.0.0
+In this version elasticsearch template in `output.conf` configmap was expanded to be fully configured from `values.yaml`
+ - decide if to add a `logstash` - toggle `logstash.enabled`
+ - decide if to add a `buffer` - toggle `buffer.enabled`
+#### The following fields were removed from the elasticsearch block in vlaues.yaml
+ - `bufferChunkLimit` in favor of `buffer.chunkLimitSize`
+ - `bufferQueueLimit` in favor of `buffer.queueLimitLength`
+ - `logstashPrefix` in favor of `logstash.enabled` and `logstash.prefix`
+#### The following fields were added
+ - `reconnectOnError`
+ - `reloadOnFailure`
+ - `reloadConnections`
+ - `buffer.enabled`
+ - `buffer.type`
+ - `buffer.path`
+ - `buffer.flushMode`
+ - `buffer.retryType`
+ - `buffer.flushThreadCount`
+ - `buffer.flushInterval`
+ - `buffer.retryForever`
+ - `buffer.retryMaxInterval`
+ - `buffer.chunkLimitSize`
+ - `buffer.queueLimitLength`
+ - `buffer.overflowAction`

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -42,89 +42,104 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd elasticsearch chart and their default values.
 
-| Parameter                                            | Description                                                                    | Default                                |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------- |
-| `affinity`                                           | Optional daemonset affinity                                                    | `{}`                                   |
-| `annotations`                                        | Optional daemonset annotations                                                 | `NULL`                                 |
-| `podAnnotations`                                     | Optional daemonset's pods annotations                                          | `NULL`                                 |
-| `configMaps.useDefaults.systemConf`                  | Use default system.conf                                                        | true                                   |
-| `configMaps.useDefaults.containersInputConf`         | Use default containers.input.conf                                              | true                                   |
-| `configMaps.useDefaults.systemInputConf`             | Use default system.input.conf                                                  | true                                   |
-| `configMaps.useDefaults.forwardInputConf`            | Use default forward.input.conf                                                 | true                                   |
-| `configMaps.useDefaults.monitoringConf`              | Use default monitoring.conf                                                    | true                                   |
-| `configMaps.useDefaults.outputConf`                  | Use default output.conf                                                        | true                                   |
-| `extraConfigMaps`                                    | Add additional Configmap or overwrite disabled default                         | `{}`                                   |
-| `awsSigningSidecar.enabled`                          | Enable AWS request signing sidecar                                             | `false`                                |
-| `awsSigningSidecar.resources`                        | AWS Sidecar resources                                                          | `{}`                                   |
-| `awsSigningSidecar.network.port`                     | AWS Sidecar exposure port                                                      | `8080`                                 |
-| `awsSigningSidecar.network.address`                  | AWS Sidecar listen address                                                     | `localhost`                            |
-| `awsSigningSidecar.network.remoteReadTimeoutSeconds` | AWS Sidecar socket read timeout when talking to ElasticSearch                  | `15`                                   |
-| `awsSigningSidecar.image.repository`                 | AWS signing sidecar repository image                                           | `abutaha/aws-es-proxy`                 |
-| `awsSigningSidecar.image.tag`                        | AWS signing sidecar repository tag                                             | `v1.0`                                 |
-| `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                |
-| `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                   |
-| `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                   |
-| `elasticsearch.bufferChunkLimit`                     | Elasticsearch buffer chunk limit                                               | `2M`                                   |
-| `elasticsearch.bufferQueueLimit`                     | Elasticsearch buffer queue limit                                               | `8`                                    |
-| `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`        |
-| `elasticsearch.logstashPrefix`                       | Elasticsearch Logstash prefix                                                  | `logstash`                             |
-| `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                   |
-| `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                 |
-| `elasticsearch.sslVerify`                            | Elasticsearch Auth SSL verify                                                  | `true`                                 |
-| `elasticsearch.sslVersion`                           | Elasticsearch tls version setting                                              | `TLSv1_2`                              |
-| `elasticsearch.outputType`                           | Elasticsearch output type                                                      | `elasticsearch`                        |
-| `elasticsearch.typeName`                             | Elasticsearch type name                                                        | `_doc`                                 |
-| `elasticsearch.logLevel`                             | Elasticsearch global log level                                                 | `info`                                 |
-| `env`                                                | List of env vars that are added to the fluentd pods                            | `{}`                                   |
-| `fluentdArgs`                                        | Fluentd args                                                                   | `--no-supervisor -q`                   |
-| `secret`                                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                   |
-| `extraVolumeMounts`                                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                   |
-| `extraVolume`                                        | Extra volume                                                                   | `[]`                                   |
-| `hostLogDir.varLog`                                  | Specify where fluentd can find var log                                         | `/var/log`                             |
-| `hostLogDir.dockerContainers`                        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`           |
-| `hostLogDir.libSystemdDir`                           | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                           |
-| `image.repository`                                   | Image                                                                          | `quay.io/fluentd_elasticsearch/fluentd`|
-| `image.tag`                                          | Image tag                                                                      | `v3.0.1`                               |
-| `image.pullPolicy`                                   | Image pull policy                                                              | `IfNotPresent`                         |
-| `image.pullSecrets`                                  | Image pull secrets                                                             | ``                                     |
-| `livenessProbe.enabled`                              | Whether to enable livenessProbe                                                | `true`                                 |
-| `livenessProbe.initialDelaySeconds`                  | livenessProbe initial delay seconds                                            | `600`                                  |
-| `livenessProbe.periodSeconds`                        | livenessProbe period seconds                                                   | `60`                                   |
-| `livenessProbe.kind`                                 | livenessProbe kind                                                             | `Set to a Linux compatible command`    |
-| `nodeSelector`                                       | Optional daemonset nodeSelector                                                | `{}`                                   |
-| `podSecurityPolicy.annotations`                      | Specify pod annotations in the pod security policy                             | `{}`                                   |
-| `podSecurityPolicy.enabled`                          | Specify if a pod security policy must be created                               | `false`                                |
-| `priorityClassName`                                  | Optional PriorityClass for pods                                                | `""`                                   |
-| `prometheusRule.enabled`                             | Whether to enable Prometheus prometheusRule                                    | `false`                                |
-| `prometheusRule.prometheusNamespace`                 | Namespace for prometheusRule                                                   | `monitoring`                           |
-| `prometheusRule.labels`                              | Optional labels for prometheusRule                                             | `{}`                                   |
-| `rbac.create`                                        | RBAC                                                                           | `true`                                 |
-| `resources.limits.cpu`                               | CPU limit                                                                      | `100m`                                 |
-| `resources.limits.memory`                            | Memory limit                                                                   | `500Mi`                                |
-| `resources.requests.cpu`                             | CPU request                                                                    | `100m`                                 |
-| `resources.requests.memory`                          | Memory request                                                                 | `200Mi`                                |
-| `service`                                            | Service definition                                                             | `{}`                                   |
-| `service.ports`                                      | List of service ports dict [{name:...}...]                                     | Not Set                                |
-| `service.ports[].type`                               | Service type (ClusterIP/NodePort)                                              | `ClusterIP`                            |
-| `service.ports[].name`                               | One of service ports name                                                      | Not Set                                |
-| `service.ports[].port`                               | Service port                                                                   | Not Set                                |
-| `service.ports[].nodePort`                           | NodePort port (when service.type is NodePort)                                  | Not Set                                |
-| `service.ports[].protocol`                           | Service protocol(optional, can be TCP/UDP)                                     | Not Set                                |
-| `serviceAccount.create`                              | Specifies whether a service account should be created.                         | `true`                                 |
-| `serviceAccount.name`                                | Name of the service account.                                                   | `""`                                   |
-| `serviceAccount.annotations`                         | Specify annotations in the pod service account                                 | `{}`                                   |
-| `serviceMetric.enabled`                              | Generate the metric service regardless of whether serviceMonitor is enabled.   | `false`                                |
-| `serviceMonitor.enabled`                             | Whether to enable Prometheus serviceMonitor                                    | `false`                                |
-| `serviceMonitor.port`                                | Define on which port the ServiceMonitor should scrape                          | `24231`                                |
-| `serviceMonitor.interval`                            | Interval at which metrics should be scraped                                    | `10s`                                  |
-| `serviceMonitor.path`                                | Path for Metrics                                                               | `/metrics`                             |
-| `serviceMonitor.labels`                              | Optional labels for serviceMonitor                                             | `{}`                                   |
-| `serviceMonitor.metricRelabelings`                   | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                   |
-| `serviceMonitor.relabelings`                         | Optional relabel configs to apply to samples before scraping                   | `[]`                                   |
-| `serviceMonitor.jobLabel`                            | Label whose value will define the job name                                     | `app.kubernetes.io/instance`           |
-| `serviceMonitor.type`                                | Optional the type of the metrics service                                       | `ClusterIP`                            |
-| `tolerations`                                        | Optional daemonset tolerations                                                 | `[]`                                   |
-| `updateStrategy`                                     | Optional daemonset update strategy                                             | `type: RollingUpdate`                  |
+| Parameter                                            | Description                                                                    | Default                                            |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------- |
+| `affinity`                                           | Optional daemonset affinity                                                    | `{}`                                               |
+| `annotations`                                        | Optional daemonset annotations                                                 | `NULL`                                             |
+| `podAnnotations`                                     | Optional daemonset's pods annotations                                          | `NULL`                                             |
+| `configMaps.useDefaults.systemConf`                  | Use default system.conf                                                        | true                                               |
+| `configMaps.useDefaults.containersInputConf`         | Use default containers.input.conf                                              | true                                               |
+| `configMaps.useDefaults.systemInputConf`             | Use default system.input.conf                                                  | true                                               |
+| `configMaps.useDefaults.forwardInputConf`            | Use default forward.input.conf                                                 | true                                               |
+| `configMaps.useDefaults.monitoringConf`              | Use default monitoring.conf                                                    | true                                               |
+| `configMaps.useDefaults.outputConf`                  | Use default output.conf                                                        | true                                               |
+| `extraConfigMaps`                                    | Add additional Configmap or overwrite disabled default                         | `{}`                                               |
+| `awsSigningSidecar.enabled`                          | Enable AWS request signing sidecar                                             | `false`                                            |
+| `awsSigningSidecar.resources`                        | AWS Sidecar resources                                                          | `{}`                                               |
+| `awsSigningSidecar.network.port`                     | AWS Sidecar exposure port                                                      | `8080`                                             |
+| `awsSigningSidecar.network.address`                  | AWS Sidecar listen address                                                     | `localhost`                                        |
+| `awsSigningSidecar.network.remoteReadTimeoutSeconds` | AWS Sidecar socket read timeout when talking to ElasticSearch                  | `15`                                               |
+| `awsSigningSidecar.image.repository`                 | AWS signing sidecar repository image                                           | `abutaha/aws-es-proxy`                             |
+| `awsSigningSidecar.image.tag`                        | AWS signing sidecar repository tag                                             | `v1.0`                                             |
+| `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
+| `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                               |
+| `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                               |
+| `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
+| `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |
+| `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled                                                 | `true`                                             |
+| `elasticsearch.logstash.prefix`                      | Elasticsearch Logstash prefix                                                  | `logstash`                                         |
+| `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                               |
+| `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                             |
+| `elasticsearch.sslVerify`                            | Elasticsearch Auth SSL verify                                                  | `true`                                             |
+| `elasticsearch.sslVersion`                           | Elasticsearch tls version setting                                              | `TLSv1_2`                                          |
+| `elasticsearch.outputType`                           | Elasticsearch output type                                                      | `elasticsearch`                                    |
+| `elasticsearch.typeName`                             | Elasticsearch type name                                                        | `_doc`                                             |
+| `elasticsearch.logLevel`                             | Elasticsearch global log level                                                 | `info`                                             |
+| `elasticsearch.reconnectOnError`                     | Elasticsearch Reconnect on error                                               | `true`                                             |
+| `elasticsearch.reloadOnFailure`                      | Elasticsearch Reload on failure                                                | `false`                                            |
+| `elasticsearch.reloadConnections`                    | Elasticsearch reload connections                                               | `false`                                            |
+| `elasticsearch.buffer.enabled`                       | Elasticsearch Buffer enabled                                                   | `true`                                             |
+| `elasticsearch.buffer.type`                          | Elasticsearch Buffer type                                                      | `file`                                             |
+| `elasticsearch.buffer.path`                          | Elasticsearch Buffer path                                                      | `/var/log/fluentd-buffers/kubernetes.system.buffer`|
+| `elasticsearch.buffer.flushMode`                     | Elasticsearch Buffer flush mode                                                | `interval`                                         |
+| `elasticsearch.buffer.retryType`                     | Elasticsearch Buffer retry type                                                | `exponential_backoff`                              |
+| `elasticsearch.buffer.flushThreadCount`              | Elasticsearch Buffer flush thread count                                        | `2`                                                |
+| `elasticsearch.buffer.flushInterval`                 | Elasticsearch Buffer flush interval                                            | `5s`                                               |
+| `elasticsearch.buffer.retryForever`                  | Elasticsearch Buffer retry forever                                             | `true`                                             |
+| `elasticsearch.buffer.retryMaxInterval`              | Elasticsearch Buffer retry max interval                                        | `30`                                               |
+| `elasticsearch.buffer.chunkLimitSize`                | Elasticsearch Buffer chunk limit size                                          | `2M`                                               |
+| `elasticsearch.buffer.queueLimitLength`              | Elasticsearch Buffer queue limit size                                          | `8`                                                |
+| `elasticsearch.buffer.overflowAction`                | Elasticsearch Buffer over flow action                                          | `block`                                            |
+| `env`                                                | List of env vars that are added to the fluentd pods                            | `{}`                                               |
+| `fluentdArgs`                                        | Fluentd args                                                                   | `--no-supervisor -q`                               |
+| `secret`                                             | List of env vars that are set from secrets and added to the fluentd pods       | `[]`                                               |
+| `extraVolumeMounts`                                  | Mount extra volume, required to mount ssl certificates when ES has tls enabled | `[]`                                               |
+| `extraVolume`                                        | Extra volume                                                                   | `[]`                                               |
+| `hostLogDir.varLog`                                  | Specify where fluentd can find var log                                         | `/var/log`                                         |
+| `hostLogDir.dockerContainers`                        | Specify where fluentd can find logs for docker container                       | `/var/lib/docker/containers`                       |
+| `hostLogDir.libSystemdDir`                           | Specify where fluentd can find logs for lib Systemd                            | `/usr/lib64`                                       |
+| `image.repository`                                   | Image                                                                          | `quay.io/fluentd_elasticsearch/fluentd`            |
+| `image.tag`                                          | Image tag                                                                      | `v3.0.1`                                           |
+| `image.pullPolicy`                                   | Image pull policy                                                              | `IfNotPresent`                                     |
+| `image.pullSecrets`                                  | Image pull secrets                                                             | ``                                                 |
+| `livenessProbe.enabled`                              | Whether to enable livenessProbe                                                | `true`                                             |
+| `livenessProbe.initialDelaySeconds`                  | livenessProbe initial delay seconds                                            | `600`                                              |
+| `livenessProbe.periodSeconds`                        | livenessProbe period seconds                                                   | `60`                                               |
+| `livenessProbe.kind`                                 | livenessProbe kind                                                             | `Set to a Linux compatible command`                |
+| `nodeSelector`                                       | Optional daemonset nodeSelector                                                | `{}`                                               |
+| `podSecurityPolicy.annotations`                      | Specify pod annotations in the pod security policy                             | `{}`                                               |
+| `podSecurityPolicy.enabled`                          | Specify if a pod security policy must be created                               | `false`                                            |
+| `priorityClassName`                                  | Optional PriorityClass for pods                                                | `""`                                               |
+| `prometheusRule.enabled`                             | Whether to enable Prometheus prometheusRule                                    | `false`                                            |
+| `prometheusRule.prometheusNamespace`                 | Namespace for prometheusRule                                                   | `monitoring`                                       |
+| `prometheusRule.labels`                              | Optional labels for prometheusRule                                             | `{}`                                               |
+| `rbac.create`                                        | RBAC                                                                           | `true`                                             |
+| `resources.limits.cpu`                               | CPU limit                                                                      | `100m`                                             |
+| `resources.limits.memory`                            | Memory limit                                                                   | `500Mi`                                            |
+| `resources.requests.cpu`                             | CPU request                                                                    | `100m`                                             |
+| `resources.requests.memory`                          | Memory request                                                                 | `200Mi`                                            |
+| `service`                                            | Service definition                                                             | `{}`                                               |
+| `service.ports`                                      | List of service ports dict [{name:...}...]                                     | Not Set                                            |
+| `service.ports[].type`                               | Service type (ClusterIP/NodePort)                                              | `ClusterIP`                                        |
+| `service.ports[].name`                               | One of service ports name                                                      | Not Set                                            |
+| `service.ports[].port`                               | Service port                                                                   | Not Set                                            |
+| `service.ports[].nodePort`                           | NodePort port (when service.type is NodePort)                                  | Not Set                                            |
+| `service.ports[].protocol`                           | Service protocol(optional, can be TCP/UDP)                                     | Not Set                                            |
+| `serviceAccount.create`                              | Specifies whether a service account should be created.                         | `true`                                             |
+| `serviceAccount.name`                                | Name of the service account.                                                   | `""`                                               |
+| `serviceAccount.annotations`                         | Specify annotations in the pod service account                                 | `{}`                                               |
+| `serviceMetric.enabled`                              | Generate the metric service regardless of whether serviceMonitor is enabled.   | `false`                                            |
+| `serviceMonitor.enabled`                             | Whether to enable Prometheus serviceMonitor                                    | `false`                                            |
+| `serviceMonitor.port`                                | Define on which port the ServiceMonitor should scrape                          | `24231`                                            |
+| `serviceMonitor.interval`                            | Interval at which metrics should be scraped                                    | `10s`                                              |
+| `serviceMonitor.path`                                | Path for Metrics                                                               | `/metrics`                                         |
+| `serviceMonitor.labels`                              | Optional labels for serviceMonitor                                             | `{}`                                               |
+| `serviceMonitor.metricRelabelings`                   | Optional metric relabel configs to apply to samples before ingestion           | `[]`                                               |
+| `serviceMonitor.relabelings`                         | Optional relabel configs to apply to samples before scraping                   | `[]`                                               |
+| `serviceMonitor.jobLabel`                            | Label whose value will define the job name                                     | `app.kubernetes.io/instance`                       |
+| `serviceMonitor.type`                                | Optional the type of the metrics service                                       | `ClusterIP`                                        |
+| `tolerations`                                        | Optional daemonset tolerations                                                 | `[]`                                               |
+| `updateStrategy`                                     | Optional daemonset update strategy                                             | `type: RollingUpdate`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -496,7 +496,7 @@ data:
       @id elasticsearch
       @type "#{ENV['OUTPUT_TYPE']}"
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
-      include_tag_key true
+      include_tag_key "#{ENV['OUTPUT_INCLUDE_TAG_KEY']}"
       hosts "#{ENV['OUTPUT_HOSTS']}"
       path "#{ENV['OUTPUT_PATH']}"
       scheme "#{ENV['OUTPUT_SCHEME']}"
@@ -509,22 +509,30 @@ data:
       user "#{ENV['OUTPUT_USER']}"
       password "#{ENV['OUTPUT_PASSWORD']}"
 {{- end }}
-      logstash_format true
+{{- if .Values.elasticsearch.logstash.enabled }}
+      logstash_format "#{ENV['LOGSTASH_FORMAT']}"
       logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
-      reconnect_on_error true
+{{- else }}
+      logstash_format "#{ENV['LOGSTASH_FORMAT']}"
+{{- end }}
+      reconnect_on_error "#{ENV['OUTPUT_RECONNECT_ON_ERROR']}"
+      reload_on_failure "#{ENV['OUTPUT_RELOAD_ON_FAILURE']}"
+      reload_connections "#{ENV['OUTPUT_RELOAD_CONNECTIONS']}"
+{{- if .Values.elasticsearch.buffer.enabled }}
       <buffer>
-        @type file
-        path /var/log/fluentd-buffers/kubernetes.system.buffer
-        flush_mode interval
-        retry_type exponential_backoff
-        flush_thread_count 2
-        flush_interval 5s
-        retry_forever
-        retry_max_interval 30
+        @type "#{ENV['OUTPUT_BUFFER_TYPE']}"
+        path "#{ENV['OUTPUT_BUFFER_PATH']}"
+        flush_mode "#{ENV['OUTPUT_BUFFER_FLUSH_MODE']}"
+        retry_type "#{ENV['OUTPUT_BUFFER_RETRY_TYPE']}"
+        flush_thread_count "#{ENV['OUTPUT_BUFFER_FLUSH_THREAD_TYPE']}"
+        flush_interval "#{ENV['OUTPUT_BUFFER_FLUSH_INTERVAL']}"
+        retry_forever "#{ENV['OUTPUT_BUFFER_RETRY_FOREVER']}"
+        retry_max_interval "#{ENV['OUTPUT_BUFFER_RETRY_MAX_INTERVAL']}"
         chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
         queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
-        overflow_action block
+        overflow_action "#{ENV['OUTPUT_BUFFER_OVERFLOW_ACTION']}"
       </buffer>
+{{- end }}
     </match>
     </label>
 {{- end }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -74,7 +74,9 @@ spec:
 {{- end }}
 {{- end }}
         - name: LOGSTASH_PREFIX
-          value: {{ .Values.elasticsearch.logstashPrefix | quote }}
+          value: {{ .Values.elasticsearch.logstash.prefix | quote }}
+        - name: LOGSTASH_FORMAT
+          value: {{ .Values.elasticsearch.logstash.enabled | quote }}
         - name: OUTPUT_SCHEME
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'http'
@@ -90,11 +92,37 @@ spec:
         - name: OUTPUT_TYPE_NAME
           value: {{ .Values.elasticsearch.typeName | quote }}
         - name: OUTPUT_BUFFER_CHUNK_LIMIT
-          value: {{ .Values.elasticsearch.bufferChunkLimit | quote }}
+          value: {{ .Values.elasticsearch.buffer.chunkLimitSize | quote }}
         - name: OUTPUT_BUFFER_QUEUE_LIMIT
-          value: {{ .Values.elasticsearch.bufferQueueLimit | quote }}
+          value: {{ .Values.elasticsearch.buffer.queueLimitLength | quote }}
+        - name: OUTPUT_BUFFER_TYPE
+          value: {{ .Values.elasticsearch.buffer.type | quote }}
+        - name: OUTPUT_BUFFER_PATH
+          value: {{ .Values.elasticsearch.buffer.path | quote }}
+        - name: OUTPUT_BUFFER_FLUSH_MODE
+          value: {{ .Values.elasticsearch.buffer.flushMode | quote }}
+        - name: OUTPUT_BUFFER_RETRY_TYPE
+          value: {{ .Values.elasticsearch.buffer.retryType | quote }}
+        - name: OUTPUT_BUFFER_FLUSH_THREAD_TYPE
+          value: {{ .Values.elasticsearch.buffer.flushThreadCount | quote }}
+        - name: OUTPUT_BUFFER_FLUSH_INTERVAL
+          value: {{ .Values.elasticsearch.buffer.flushInterval | quote }}
+        - name: OUTPUT_BUFFER_RETRY_FOREVER
+          value: {{ .Values.elasticsearch.buffer.retryForever | quote }}
+        - name: OUTPUT_BUFFER_RETRY_MAX_INTERVAL
+          value: {{ .Values.elasticsearch.buffer.retryMaxInterval | quote }}
+        - name: OUTPUT_BUFFER_OVERFLOW_ACTION
+          value: {{ .Values.elasticsearch.buffer.overflowAction | quote }}
         - name: OUTPUT_LOG_LEVEL
           value: {{ .Values.elasticsearch.logLevel | quote }}
+        - name: OUTPUT_INCLUDE_TAG_KEY
+          value: {{ .Values.elasticsearch.includeTagKey | quote }}
+        - name: OUTPUT_RECONNECT_ON_ERROR
+          value: {{ .Values.elasticsearch.reconnectOnError | quote }}
+        - name: OUTPUT_RELOAD_ON_FAILURE
+          value: {{ .Values.elasticsearch.reloadOnFailure | quote }}
+        - name: OUTPUT_RELOAD_CONNECTIONS
+          value: {{ .Values.elasticsearch.reloadConnections | quote }}
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -60,10 +60,11 @@ elasticsearch:
     enabled: false
     user: "yourUser"
     password: "yourPass"
-  bufferChunkLimit: "2M"
-  bufferQueueLimit: 8
+  includeTagKey: true
   hosts: ["elasticsearch-client:9200"]
-  logstashPrefix: "logstash"
+  logstash:
+    enabled: true
+    prefix: "logstash"
   path: ""
   scheme: "http"
   sslVerify: true
@@ -71,7 +72,22 @@ elasticsearch:
   outputType: "elasticsearch"
   typeName: "_doc"
   logLevel: "info"
-
+  reconnectOnError: true
+  reloadOnFailure: false
+  reloadConnections: false
+  buffer:
+    enabled: true
+    type: "file"
+    path: "/var/log/fluentd-buffers/kubernetes.system.buffer"
+    flushMode: "interval"
+    retryType: "exponential_backoff"
+    flushThreadCount: 2
+    flushInterval: "5s"
+    retryForever: true
+    retryMaxInterval: 30
+    chunkLimitSize: "2M"
+    queueLimitLength: 8
+    overflowAction: "block"
 
 # If you want to change args of fluentd process
 # by example you can add -vv to launch with trace log


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
We at SAP are using "fluentd-elasticsearch" image often and require the following parameters to be remotely configurable from the values.yaml file

1. Conditioning on logstash_format and using Env
2. Adding reload_on_failure and using Env
3. Adding reload_connections and using Env
4. Using Env for all buffer block"

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #339


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
