### PR TITLE
fix(labels): remove deprecated label

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.0.0
+version: 9.0.1
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.rbac.create -}}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.rbac.create -}}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -1,10 +1,12 @@
+
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -1,4 +1,6 @@
-{{- if semverCompare ">= 1.9" .Capabilities.KubeVersion.GitVersion -}}
+
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
+{{- if semverCompare ">= 1.9" $striped_version -}}
 apiVersion: apps/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -8,7 +10,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
@@ -27,11 +29,11 @@ spec:
     metadata:
       labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 8 }}
-        {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare "< 1.6" $striped_version }}
         kubernetes.io/cluster-service: "true"
         {{- end }}
       annotations:
-        {{- if semverCompare "< 1.13" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare "< 1.13" $striped_version }}
         # This annotation ensures that fluentd does not get evicted if the node
         # supports critical pod annotation based priority scheme.
         # Note that this does not guarantee admission on the nodes (#40573).
@@ -145,9 +147,9 @@ spec:
         - name: K8S_NODE_NAME
           valueFrom:
             fieldRef:
-              {{ if semverCompare ">= 1.9" .Capabilities.KubeVersion.GitVersion -}}
+              {{- if semverCompare ">= 1.9" $striped_version }}
               apiVersion: v1
-              {{- end -}}
+              {{- end }}
               fieldPath: spec.nodeName
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -1,10 +1,14 @@
+{{- if semverCompare ">= 1.9" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: apps/v1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: DaemonSet
 metadata:
   name: {{ include "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
@@ -23,7 +27,7 @@ spec:
     metadata:
       labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 8 }}
-        {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
         kubernetes.io/cluster-service: "true"
         {{- end }}
       annotations:
@@ -141,6 +145,9 @@ spec:
         - name: K8S_NODE_NAME
           valueFrom:
             fieldRef:
+              {{ if semverCompare ">= 1.9" .Capabilities.KubeVersion.GitVersion -}}
+              apiVersion: v1
+              {{- end -}}
               fieldPath: spec.nodeName
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -1,4 +1,5 @@
 {{- if or (.Values.serviceMonitor.enabled) (.Values.serviceMetric.enabled) }}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 ---
 apiVersion: v1
 kind: Service
@@ -6,7 +7,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" $ }}-metrics
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/metrics-service.yaml
+++ b/charts/fluentd-elasticsearch/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" $ }}-metrics
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/charts/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-{{- if semverCompare "> 1.15" .Capabilities.KubeVersion.GitVersion -}}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
+{{- if semverCompare "> 1.15" $striped_version -}}
 apiVersion: policy/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -9,7 +10,7 @@ metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+++ b/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.prometheusRule.enabled }}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -1,16 +1,17 @@
 {{- if .Values.podSecurityPolicy.enabled }}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
-{{- if semverCompare "> 1.15" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "> 1.15" $striped_version }}
 - apiGroups: ['policy']
 {{- else }}
 - apiGroups: ['extensions']

--- a/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/charts/fluentd-elasticsearch/templates/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -1,12 +1,13 @@
 
 {{- if .Values.podSecurityPolicy.enabled }}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service-account.yaml
+++ b/charts/fluentd-elasticsearch/templates/service-account.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,7 +9,7 @@ metadata:
     helm.sh/chart: {{ include "fluentd-elasticsearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.service }}
 {{- range $port := .Values.service.ports  }}
 {{- $service_type := $port.type | default "ClusterIP" }}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 ---
 apiVersion: v1
 kind: Service
@@ -8,7 +9,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" $ | trunc 50 }}-{{ $port.name | trunc 12 }}
   labels:
 {{ include "fluentd-elasticsearch.labels" $ | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "fluentd-elasticsearch.fullname" $ | trunc 50 }}-{{ $port.name | trunc 12 }}
   labels:
 {{ include "fluentd-elasticsearch.labels" $ | indent 4 }}
-    {{- if semverCompare "> 1.6" $.Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "> 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile

--- a/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.serviceMonitor.enabled }}
+{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
 {{ include "fluentd-elasticsearch.labels" . | indent 4 }}
-    {{- if semverCompare "< 1.6" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare "< 1.6" $striped_version }}
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
Is this a BUG REPORT or FEATURE REQUEST? :
FEATURE REQUEST

Version of Helm and Kubernetes:
Helm v3.1.2 and Kubernetes v1.15.9

Which chart in which version:
9.0.0

What happened:


#### What this PR does / why we need it:

Avoid diff in our CI because of k8s removing this label deprecated label constantly.

#### Which issue this PR fixes
  - fixes #343

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
