### PR TITLE
[fluentd-elasticsearch] Make index_name changable

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.0.0
+version: 9.1.0
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -66,8 +66,9 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                               |
 | `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
 | `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |
-| `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled                                                 | `true`                                             |
+| `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled (supersedes indexName)                          | `true`                                             |
 | `elasticsearch.logstash.prefix`                      | Elasticsearch Logstash prefix                                                  | `logstash`                                         |
+| `elasticsearch.indexName`                            | Elasticsearch Index Name                                                       | `fluentd`                                         |
 | `elasticsearch.path`                                 | Elasticsearch Path                                                             | `""`                                               |
 | `elasticsearch.scheme`                               | Elasticsearch scheme setting                                                   | `http`                                             |
 | `elasticsearch.sslVerify`                            | Elasticsearch Auth SSL verify                                                  | `true`                                             |

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -514,6 +514,7 @@ data:
       logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
 {{- else }}
       logstash_format "#{ENV['LOGSTASH_FORMAT']}"
+      index_name "#{ENV['INDEX_NAME']}"
 {{- end }}
       reconnect_on_error "#{ENV['OUTPUT_RECONNECT_ON_ERROR']}"
       reload_on_failure "#{ENV['OUTPUT_RELOAD_ON_FAILURE']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -77,6 +77,8 @@ spec:
           value: {{ .Values.elasticsearch.logstash.prefix | quote }}
         - name: LOGSTASH_FORMAT
           value: {{ .Values.elasticsearch.logstash.enabled | quote }}
+        - name: INDEX_NAME
+          value: {{ .Values.elasticsearch.indexName | quote }}
         - name: OUTPUT_SCHEME
           {{- if .Values.awsSigningSidecar.enabled }}
           value: 'http'

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -62,6 +62,7 @@ elasticsearch:
     password: "yourPass"
   includeTagKey: true
   hosts: ["elasticsearch-client:9200"]
+  indexName: "fluentd"
   logstash:
     enabled: true
     prefix: "logstash"


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
A new feature to have a configurable [index_name](https://docs.fluentd.org/output/elasticsearch#index_name-optional).

This should enable people using this chart to configure the index_name to their liking and requirements.
Before the PR it was a choice between a large `fluentd` index or a daily `<logstashPrefix>-%Y.%m.%d` index.

#### Which issue this PR fixes
  - N/A


#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
