### PR TITLE
[fluentd-elasticsearch] Provide option to disable settings elasticsearch hosts

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.1.1
+version: 9.2.0
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
 | `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                               |
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                               |
-| `elasticsearch.setHosts`                             | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
+| `elasticsearch.useOutputHostEnvVar`                  | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
 | `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
 | `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |
 | `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled (supersedes indexName)                          | `true`                                             |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
 | `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                               |
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                               |
-| `elasticsearch.useOutputHostEnvVar`                  | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
+| `elasticsearch.setOutputHostEnvVar`                  | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
 | `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
 | `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |
 | `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled (supersedes indexName)                          | `true`                                             |

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.auth.enabled`                         | Elasticsearch Auth enabled                                                     | `false`                                            |
 | `elasticsearch.auth.user`                            | Elasticsearch Auth User                                                        | `""`                                               |
 | `elasticsearch.auth.password`                        | Elasticsearch Auth Password                                                    | `""`                                               |
+| `elasticsearch.setHosts`                             | Use `elasticsearch.hosts` (Disable this to manually configure hosts)           | `true`                                             |
 | `elasticsearch.hosts`                                | Elasticsearch Hosts List (host and port)                                       | `["elasticsearch-client:9200"]`                    |
 | `elasticsearch.includeTagKey`                        | Elasticsearch Including of Tag key                                             | `true`                                             |
 | `elasticsearch.logstash.enabled`                     | Elasticsearch Logstash enabled (supersedes indexName)                          | `true`                                             |

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: {{ .Values.fluentdArgs | quote }}
-        {{- if .Values.elasticsearch.setHosts }}
+        {{- if .Values.elasticsearch.useOutputHostEnvVar }}
         - name: OUTPUT_HOSTS
           {{- if .Values.awsSigningSidecar.enabled }}
           value: "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -63,12 +63,14 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: {{ .Values.fluentdArgs | quote }}
+        {{- if .Values.elasticsearch.setHosts }}
         - name: OUTPUT_HOSTS
           {{- if .Values.awsSigningSidecar.enabled }}
           value: "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"
           {{- else }}
           value: "{{- join "," .Values.elasticsearch.hosts }}"
           {{- end }}
+        {{- end }}
         - name: OUTPUT_PATH
           value: {{ .Values.elasticsearch.path | quote }}
 {{- if .Values.elasticsearch.auth.enabled }}

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: {{ .Values.fluentdArgs | quote }}
-        {{- if .Values.elasticsearch.useOutputHostEnvVar }}
+        {{- if .Values.elasticsearch.setOutputHostEnvVar }}
         - name: OUTPUT_HOSTS
           {{- if .Values.awsSigningSidecar.enabled }}
           value: "{{ .Values.awsSigningSidecar.network.address }}:{{ .Values.awsSigningSidecar.network.port }}"

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -61,8 +61,8 @@ elasticsearch:
     user: "yourUser"
     password: "yourPass"
   includeTagKey: true
-  useOutputHostEnvVar: true
-  # If useOutputHostEnvVar is false this value is ignored
+  setOutputHostEnvVar: true
+  # If setOutputHostEnvVar is false this value is ignored
   hosts: ["elasticsearch-client:9200"]
   indexName: "fluentd"
   logstash:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -61,6 +61,7 @@ elasticsearch:
     user: "yourUser"
     password: "yourPass"
   includeTagKey: true
+  setHosts: true
   hosts: ["elasticsearch-client:9200"]
   indexName: "fluentd"
   logstash:

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -61,7 +61,8 @@ elasticsearch:
     user: "yourUser"
     password: "yourPass"
   includeTagKey: true
-  setHosts: true
+  useOutputHostEnvVar: true
+  # If useOutputHostEnvVar is false this value is ignored
   hosts: ["elasticsearch-client:9200"]
   indexName: "fluentd"
   logstash:


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR provides a way to disable setting the `OUTPUT_HOSTS` environment variable from the `elasticsearch.hosts` value. This feature allows users to manually set `OUTPUT_HOSTS` using a secret or alternative method if they desire.

#### Which issue this PR fixes
  - fixes #348 


#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
