### PR TITLE
[fluentd-elasticsearch] adding request timeout config

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.2.0
+version: 9.2.1
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.2.1
+version: 9.3.0
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.reconnectOnError`                     | Elasticsearch Reconnect on error                                               | `true`                                             |
 | `elasticsearch.reloadOnFailure`                      | Elasticsearch Reload on failure                                                | `false`                                            |
 | `elasticsearch.reloadConnections`                    | Elasticsearch reload connections                                               | `false`                                            |
+| `elasticsearch.requestTimeout`                       | Elasticsearch request timeout                                               | `5s`                                            |
 | `elasticsearch.buffer.enabled`                       | Elasticsearch Buffer enabled                                                   | `true`                                             |
 | `elasticsearch.buffer.type`                          | Elasticsearch Buffer type                                                      | `file`                                             |
 | `elasticsearch.buffer.path`                          | Elasticsearch Buffer path                                                      | `/var/log/fluentd-buffers/kubernetes.system.buffer`|

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -521,6 +521,7 @@ data:
       reconnect_on_error "#{ENV['OUTPUT_RECONNECT_ON_ERROR']}"
       reload_on_failure "#{ENV['OUTPUT_RELOAD_ON_FAILURE']}"
       reload_connections "#{ENV['OUTPUT_RELOAD_CONNECTIONS']}"
+      request_timeout "#{ENV['OUTPUT_REQUEST_TIMEOUT']}"
 {{- if .Values.elasticsearch.buffer.enabled }}
       <buffer>
         @type "#{ENV['OUTPUT_BUFFER_TYPE']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -133,6 +133,8 @@ spec:
           value: {{ .Values.elasticsearch.reloadOnFailure | quote }}
         - name: OUTPUT_RELOAD_CONNECTIONS
           value: {{ .Values.elasticsearch.reloadConnections | quote }}
+        - name: OUTPUT_REQUEST_TIMEOUT
+          value: {{ .Values.elasticsearch.requestTimeout | quote }}
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -78,7 +78,7 @@ elasticsearch:
   reconnectOnError: true
   reloadOnFailure: false
   reloadConnections: false
-  request_timeout: "5s"
+  requestTimeout: "5s"
   buffer:
     enabled: true
     type: "file"

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -78,6 +78,7 @@ elasticsearch:
   reconnectOnError: true
   reloadOnFailure: false
   reloadConnections: false
+  request_timeout: "5s"
   buffer:
     enabled: true
     type: "file"


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding reqeust timeout configuration variable.
This is useful when Elasticsearch cannot return response for bulk request within the default of 5 seconds.
https://github.com/uken/fluent-plugin-elasticsearch#request_timeout

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)