### PR TITLE
[fluentd-elasticsearch] fix service template rendering

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.3.0
+version: 9.3.1
 appVersion: 3.0.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/service.yaml
+++ b/charts/fluentd-elasticsearch/templates/service.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.service }}
 {{- range $port := .Values.service.ports  }}
 {{- $service_type := $port.type | default "ClusterIP" }}
-{{- $striped_version := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
+{{- $striped_version := (split "-" $.Capabilities.KubeVersion.GitVersion)._0 -}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Issue triggered when defining any service port as .Capabilities cannot
be evaluated inside a range loop.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
