### PR TITLE
[fluentd-elasticsearch] (PREVIEW - DO NOT MERGE) Add suppressTypeName parameter to eliminate ES 7 deprecation warnings

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.5.1
+version: 9.6.0
 appVersion: 3.0.2
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/README.md
+++ b/charts/fluentd-elasticsearch/README.md
@@ -88,6 +88,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.reloadOnFailure`                      | Elasticsearch Reload on failure                                                | `false`                                            |
 | `elasticsearch.reloadConnections`                    | Elasticsearch reload connections                                               | `false`                                            |
 | `elasticsearch.requestTimeout`                       | Elasticsearch request timeout                                                  | `5s`                                               |
+| `elasticsearch.suppressTypeName                      | Elasticsearch type name suppression (for ES >= 7)                              | `false`                                               |
 | `elasticsearch.buffer.enabled`                       | Elasticsearch Buffer enabled                                                   | `true`                                             |
 | `elasticsearch.buffer.type`                          | Elasticsearch Buffer type                                                      | `file`                                             |
 | `elasticsearch.buffer.path`                          | Elasticsearch Buffer path                                                      | `/var/log/fluentd-buffers/kubernetes.system.buffer`|

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -531,6 +531,9 @@ data:
       reload_on_failure "#{ENV['OUTPUT_RELOAD_ON_FAILURE']}"
       reload_connections "#{ENV['OUTPUT_RELOAD_CONNECTIONS']}"
       request_timeout "#{ENV['OUTPUT_REQUEST_TIMEOUT']}"
+{{- if .Values.elasticsearch.suppressTypeName }}
+      suppress_type_name "#{ENV['OUTPUT_SUPPRESS_TYPE_NAME']}"
+{{- end }}
 {{- if .Values.elasticsearch.buffer.enabled }}
       <buffer>
         @type "#{ENV['OUTPUT_BUFFER_TYPE']}"

--- a/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -151,6 +151,10 @@ spec:
           value: {{ .Values.elasticsearch.reloadConnections | quote }}
         - name: OUTPUT_REQUEST_TIMEOUT
           value: {{ .Values.elasticsearch.requestTimeout | quote }}
+{{- if .Values.elasticsearch.suppressTypeName }}
+        - name: OUTPUT_SUPPRESS_TYPE_NAME
+          value: {{ .Values.elasticsearch.suppressTypeName | quote }}
+{{- end }}
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}

--- a/charts/fluentd-elasticsearch/values.yaml
+++ b/charts/fluentd-elasticsearch/values.yaml
@@ -3,7 +3,7 @@ image:
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
-  tag: v3.0.2
+  tag: v3.0.4
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -104,6 +104,7 @@ elasticsearch:
   reloadOnFailure: false
   reloadConnections: false
   requestTimeout: "5s"
+  suppressTypeName: false
   buffer:
     enabled: true
     type: "file"


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds `elasticsearch.suppressTypeName` as a chart parameter in order to leverage the `suppress_type_name` option on the fluentd-elasticsearch plugin.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #381


#### Special notes for your reviewer:

Please note that this PR will not work at this moment! At the time this PR is being opened, the referenced fluend-elasticsearch image version (3.0.4) is in PR but not yet been published. (https://github.com/kubernetes/kubernetes/pull/93116)

I'm submitting this PR now so it can be reviewed and I can incorporate any feedback as needed.

Note that I have tested both the new fluentd-elasticsearch image 3.0.4 (published as a fork) as well as the changes I'm submitting here (published to a private helm repo), so I'm confident that everything will work once the k8s PR has been merged.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
