### PR TITLE
[fluentd-elasticsearch] typo in ENABLE_ILM environment variable

### DIFF
--- a/charts/fluentd-elasticsearch/Chart.yaml
+++ b/charts/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-elasticsearch
-version: 9.5.1
+version: 9.5.2
 appVersion: 3.0.2
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -521,7 +521,7 @@ data:
       index_name "#{ENV['INDEX_NAME']}"
 {{- end }}
 {{- if .Values.elasticsearch.ilm.enabled }}
-      enable_ilm "#{ENV['ENABLE_ILM']}'"
+      enable_ilm "#{ENV['ENABLE_ILM']}"
       ilm_policy_id "#{ENV['ILM_POLICY_ID']}"
       ilm_policy "#{ENV['ILM_POLICY']}"
       ilm_policies "#{ENV['ILM_POLICIES']}"


### PR DESCRIPTION
Fix typo'd single quote

A typo in the ENABLE_ILM environment variable didn't get caught previously  . 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
