### PR TITLE
Retry for PR with signed commits!

### DIFF
--- a/charts/secret-replicator/Chart.yaml
+++ b/charts/secret-replicator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.1"
+appVersion: "0.2.0"
 description: A Helm chart to replicate secret across namespaces
 name: secret-replicator
-version: 0.5.0
+version: 0.6.0
 home: https://github.com/kiwigrid/secret-replicator
 sources:
 - https://github.com/kiwigrid/secret-replicator

--- a/charts/secret-replicator/README.md
+++ b/charts/secret-replicator/README.md
@@ -28,18 +28,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the chart and their default values.
 
-| Parameter                         | Description                             | Default                                                                                     |
-| --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
-| `image.repository`                           | image name                        | `kiwigrid/secret-replicator`                                                        |
-| `image.tag`                        | image tag                      | `0.1.1`                                                                                      |
-| `image.pullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
-| `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
-| `secretList`                           | list of pull secrets                          | empty string                                                        |
-| `ignoreNamespaces`             | namespaces which should be excluded from sync                                     | `kube-system,kube-pulic`               |
-| `resources`                    | Resource limits for pod             | `{}`                                   |
-| `nodeSelector`                 | NodeSelector                                 | `{}`                                   |
-| `tolerations`                  | Tolerations                                  | `[]`                                   |
-| `affinity`                     | Affinity                                     | `{}`                                   |
+| Parameter                  | Description                                   | Default                      |
+|----------------------------|-----------------------------------------------|------------------------------|
+| `image.repository`         | image name                                    | `kiwigrid/secret-replicator` |
+| `image.tag`                | image tag                                     | `0.1.1`                      |
+| `image.pullPolicy`         | Image pull policy                             | `IfNotPresent`               |
+| `image.pullSecrets`        | Image pull secrets                            | `nil`                        |
+| `secretList`               | list of pull secrets                          | empty string                 |
+| `ignoreNamespaces`         | namespaces which should be excluded from sync | `kube-system,kube-pulic`     |
+| `secretNamespace`          | namespaces where the secrets can be found     | `<release namespace>`        |
+| `resources`                | Resource limits for pod                       | `{}`                         |
+| `nodeSelector`             | NodeSelector                                  | `{}`                         |
+| `tolerations`              | Tolerations                                   | `[]`                         |
+| `affinity`                 | Affinity                                      | `{}`                         |
+| `podSecurityContext`       | SecurityContext at pod level                  | `{}`                         |
+| `containerSecurityContext` | SecurityContext at container level            | `{}`                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/secret-replicator/README.md
+++ b/charts/secret-replicator/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the chart and their def
 | Parameter                  | Description                                   | Default                      |
 |----------------------------|-----------------------------------------------|------------------------------|
 | `image.repository`         | image name                                    | `kiwigrid/secret-replicator` |
-| `image.tag`                | image tag                                     | `0.1.1`                      |
+| `image.tag`                | image tag                                     | `0.2.0`                      |
 | `image.pullPolicy`         | Image pull policy                             | `IfNotPresent`               |
 | `image.pullSecrets`        | Image pull secrets                            | `nil`                        |
 | `secretList`               | list of pull secrets                          | empty string                 |

--- a/charts/secret-replicator/templates/deployment.yaml
+++ b/charts/secret-replicator/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "secret-replicator.fullname" . }}-sa
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}      
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -29,8 +31,12 @@ spec:
             value: {{ .Values.secretList }}
           - name: IGNORE_NAMESPACES
             value: {{ .Values.ignoreNamespaces }}
+          - name: SECRET_NAMESPACE
+            value: {{ .Values.secretNamespace | default .Release.Namespace }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.image.pullSecrets }}

--- a/charts/secret-replicator/values.yaml
+++ b/charts/secret-replicator/values.yaml
@@ -15,6 +15,10 @@ secretList: ""
 # secretList: "secret1,secret2
 
 ignoreNamespaces: "kube-system,kube-public"
+
+# If defined, allow secret-replicator to watch for secrets in _another_ namespace
+secretNamespace:
+
 rbac:
   enabled: true
 

--- a/charts/secret-replicator/values.yaml
+++ b/charts/secret-replicator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kiwigrid/secret-replicator
-  tag: 0.1.1
+  tag: 0.2.0
   pullPolicy: IfNotPresent
   ## Specify ImagePullSecrets for Pods
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
#### What this PR does / why we need it:

(this is a retry of https://github.com/kiwigrid/helm-charts/pull/417, since I couldn't get signed commits to work with the a rebase, due to my n00bness)

Adds optional support to the secret-replicator chart for:

1. Passing the `SECRET_NAMESPACE` env var 
2. Setting the pod `securityContext`
3. Setting the container `securityContext`

Why do we need this?

Firstly, in our deployment, we want to isolate secret-replicator from the secrets which it generates.

Secondly, setting `securityContexts` allows "locking-down" the pod in sense of disabling privileged mode, enforcing readOnlyRootFilesystem (only at the container level).

All the changes I've prosposed are opt-in, and I've updated the README accordingly.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://developercertificate.org) signed
- [X] Chart Version bumped (if the pr is an update to an existing chart)
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
