### PR TITLE
[prometheus-thanos] Wrap thanos querier additional flags with quotes

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.14.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.5.1
+version: 4.5.2
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/templates/querier/deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - --store={{ . }}
           {{- end }}
           {{- range $key, $value := .Values.querier.additionalFlags }}
-          - --{{ $key }}{{if $value }}={{ $value }}{{end}}
+          - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR wraps the Thanos Querier additional flags in template with `"`. This allows us to pass values that have new line characters and/or quotation marks in them. For instance, the `tracing.config` flag (see [here](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md)) accepts a YAML string, but currently when the template is rendered with a YAML valid string the output (rendered template) the querier does not start because the provided valid YAML gets broken after the template is rendered.

Signed-off-by: Emre Kartoglu <iemrek@gmail.com>


#### Special notes for your reviewer:

* I've tested the changes in a private setup.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
