### PR TITLE
[prometheus-thanos] Add Receiver, QueryFrontend and simplify tracing config

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.14.0"
+appVersion: "0.17.2"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
 version: 4.6.0

--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.14.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.5.3
+version: 4.5.4
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.14.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.5.4
+version: 4.6.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -88,8 +88,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 
 | Parameter                                  | Description                               | Default                            |
 | ------------------------------------------ | ----------------------------------------- | ---------------------------------- |
-| `tracingType` | The tracer [type](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md).  All components which support tracing will use this  | `nil` |
-| `tracingConfig` | Config for the [tracer](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md).  All components which support tracing will use this | `{}` |
+| `tracing.enabled` | Controls whether [tracing](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md) is required across all components | `false` |
+| `tracing.type` | The tracer [type](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md).  All components which support tracing will use this  | `` |
+| `tracing.config` | Config for the [tracer](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md).  All components which support tracing will use this | `{}` |
 | `bucketWebInterface.enabled` | Controls whether bucket web interface related resources should be created | `false` |
 | `bucketWebInterface.additionalAnnotations` | Additional annotations on bucket web interface pods| `{}` |
 | `bucketWebInterface.additionalFlags` | Additional command line flags | `{}` |

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -179,6 +179,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
 | `querier.readinessProbe.timeoutSeconds` | Readiness probe timeoutSeconds | `30` |
 | `querier.replicaCount` | Replica count for querier | `1` |
+| `querier.replicaLabels` | Replica reference labels which are used for query response deduplication | `[]` |
 | `querier.resources` | Resources | `{}` |
 | `querier.stores` | List of stores [see](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md) | `[]` |
 | `querier.tolerations` | Tolerations | `[]` |

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -88,6 +88,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 
 | Parameter                                  | Description                               | Default                            |
 | ------------------------------------------ | ----------------------------------------- | ---------------------------------- |
+| `tracingType` | The tracer [type](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md).  All components which support tracing will use this  | `nil` |
+| `tracingConfig` | Config for the [tracer](https://github.com/thanos-io/thanos/blob/master/docs/tracing.md).  All components which support tracing will use this | `{}` |
 | `bucketWebInterface.enabled` | Controls whether bucket web interface related resources should be created | `false` |
 | `bucketWebInterface.additionalAnnotations` | Additional annotations on bucket web interface pods| `{}` |
 | `bucketWebInterface.additionalFlags` | Additional command line flags | `{}` |
@@ -96,7 +98,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.extraEnv` | Extra env vars | `nil` |
 | `bucketWebInterface.httpServerPort` | The port to expose from the bucket web interface container | `10902` |
 | `bucketWebInterface.image.repository` | Docker image repo for bucket web interface | `quay.io/thanos/thanos` |
-| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.14.0` |
+| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.17.2` |
 | `bucketWebInterface.image.pullPolicy` | Docker image pull policy for bucket web interface| `IfNotPresent` |
 | `bucketWebInterface.serviceAccount.create` | Create service account | `true` |
 | `bucketWebInterface.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -121,8 +123,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.affinity` | Affinity | `{}` |
 | `compact.consistencyDelay` | Consistency delay | `30m` |
 | `compact.extraEnv` | Extra env vars | `nil` |
-| `compact.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
-| `compact.image.tag` | Docker image tag for store gateway | `v0.14.0` |
+| `compact.image.repository` | Docker image repo for compactor | `quay.io/thanos/thanos` |
+| `compact.image.tag` | Docker image tag for compactor | `v0.17.2` |
 | `compact.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
 | `compact.serviceAccount.create` | Create service account | `true` |
 | `compact.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -158,7 +160,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
 | `querier.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
 | `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
-| `querier.image.tag` | Docker image tag for querier | `v0.14.0` |
+| `querier.image.tag` | Docker image tag for querier | `v0.17.2` |
 | `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
 | `querier.serviceAccount.create` | Create service account | `true` |
 | `querier.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -182,6 +184,84 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.updateStrategy` | Deployment update strategy | `type: RollingUpdate` |
 | `querier.volumeMounts` | Additional volume mounts | `nil` |
 | `querier.volumes` | Additional volumes | `nil` |
+| `queryFrontend.enabled` | Controls whether query-frontend related resources should be created | `true` |
+| `queryFrontend.additionalAnnotations` | Additional annotations on query-frontend pods| `{}` |
+| `queryFrontend.additionalFlags` | Additional command line flags | `{}` |
+| `queryFrontend.additionalLabels` | Additional labels on query-frontend pods| `{}` |
+| `queryFrontend.affinity` | Affinity | `{}` |
+| `queryFrontend.autoscaling.enabled` | Controls whether query-frontend autoscaling is enabled | `false` |
+| `queryFrontend.autoscaling.maxReplicas` | Maximum number of replicas to scale to | `10` |
+| `queryFrontend.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
+| `queryFrontend.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
+| `queryFrontend.downstreamUrl` | The URL of the querier service | `the default URL of the querier service` |
+| `queryFrontend.image.repository` | Docker image repo for query-frontend | `quay.io/thanos/thanos` |
+| `queryFrontend.image.tag` | Docker image tag for query-frontend | `v0.17.2` |
+| `queryFrontend.image.pullPolicy` | Docker image pull policy for query-frontend| `IfNotPresent` |
+| `queryFrontend.serviceAccount.create` | Create service account | `true` |
+| `queryFrontend.serviceAccount.annotations` | Service account annotations | `nil` |
+| `queryFrontend.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
+| `queryFrontend.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
+| `queryFrontend.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
+| `queryFrontend.livenessProbe.timeoutSeconds` | Liveness probe timeoutSeconds | `30` |
+| `queryFrontend.logLevel` | Query-frontend log level | `info` |
+| `queryFrontend.logQueriesLongerThan` | Log queries that are slower than the specified duration. | `0` |
+| `queryFrontend.nodeSelector` | NodeSelector | `{}` |
+| `queryFrontend.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`. | `false` |
+| `queryFrontend.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `queryFrontend.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
+| `queryFrontend.querySplitInterval` |  Split query range requests by an interval and execute in parallel | `24h` |
+| `queryFrontend.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
+| `queryFrontend.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
+| `queryFrontend.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
+| `queryFrontend.readinessProbe.timeoutSeconds` | Readiness probe timeoutSeconds | `30` |
+| `queryFrontend.replicaCount` | Replica count for query-frontend | `1` |
+| `queryFrontend.resources` | Resources | `{}` |
+| `queryFrontend.stores` | List of stores [see](https://github.com/thanos-io/thanos/blob/master/docs/components/query.md) | `[]` |
+| `queryFrontend.tolerations` | Tolerations | `[]` |
+| `queryFrontend.updateStrategy` | Deployment update strategy | `type: RollingUpdate` |
+| `queryFrontend.volumeMounts` | Additional volume mounts | `nil` |
+| `queryFrontend.volumes` | Additional volumes | `nil` |
+| `receiver.enabled` | Controls whether receiver related resources should be created | `true` |
+| `receiver.affinity` | Affinity | `{}` |
+| `receiver.additionalAnnotations` | Additional annotations on receiver pods| `{}` |
+| `receiver.additionalFlags` | Additional command line flags | `{}` |
+| `receiver.additionalLabels` | Additional labels on receiver pods| `{}` |
+| `receiver.extraEnv` | Extra env vars | `nil` |
+| `receiver.image.repository` | Docker image repo for receiver | `quay.io/thanos/thanos` |
+| `receiver.image.tag` | Docker image tag for receiver | `v0.17.2` |
+| `receiver.image.pullPolicy` | Docker image pull policy for receiver | `IfNotPresent` |
+| `receiver.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
+| `receiver.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
+| `receiver.livenessProbe.successThreshold` | Liveness probe successThreshold | `1` |
+| `receiver.livenessProbe.timeoutSeconds` | Liveness probe timeoutSeconds | `30` |
+| `receiver.logLevel` | Receiver log level | `info` |
+| `receiver.nodeSelector` | NodeSelector | `{}` |
+| `receiver.objStoreConfig` | Config for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `{}` |
+| `receiver.objStoreConfigFile` | Path to config file for the [bucket store](https://github.com/thanos-io/thanos/blob/master/docs/storage.md). Either this or `objStoreType` + `objStoreConfig`. | `nil` |
+| `receiver.objStoreType` | Object store [type](https://github.com/thanos-io/thanos/blob/master/docs/storage.md) | `GCS` |
+| `receiver.persistentVolume.enabled` | Persistent volume enabled | `true` |
+| `receiver.persistentVolume.accessModes` | Persistent volume accessModes | `[ReadWriteOnce]` |
+| `receiver.persistentVolume.annotations` | Persistent volume annotations | `{}` |
+| `receiver.persistentVolume.existingClaim` | Persistent volume existingClaim | `""` |
+| `receiver.persistentVolume.size` | Persistent volume size | `2Gi` |
+| `receiver.persistentVolume.storageClass` | Persistent volume storage class name | `""` |
+| `receiver.podNumericalPriorityEnabled` | Enables use of the `podPriority`. Either this or `podPriorityClassName`. | `false` |
+| `receiver.podPriority` | Numerical value of the pod priority. Enabled by `podNumericalPriorityEnabled` | `0` |
+| `receiver.podPriorityClassName` | Name of the pod priority class to use. Either this or `podNumericalPriorityEnabled` | `""` |
+| `receiver.readinessProbe.initialDelaySeconds` | Readiness probe initialDelaySeconds | `30` |
+| `receiver.readinessProbe.periodSeconds` | Readiness probe periodSeconds | `10` |
+| `receiver.readinessProbe.successThreshold` | Readiness probe successThreshold | `1` |
+| `receiver.readinessProbe.timeoutSeconds` |Readiness probe timeoutSeconds | `30` |
+| `receiver.replicaCount` | Replica count for receiver | `1` |
+| `receiver.replicationFactor` | Number of times to replicate incoming write requests | `1` |
+| `receiver.resources` | Resources | `{}` |
+| `receiver.serviceAccount.create` | Create service account | `true` |
+| `receiver.serviceAccount.annotations` | Service account annotations | `nil` |
+| `receiver.tolerations` | Tolerations | `[]` |
+| `receiver.tsdbRetention` | The period to retain TSDB blocks in the receiver | `1d` |
+| `receiver.updateStrategy` | StatefulSet update strategy | `type: RollingUpdate` |
+| `receiver.volumeMounts` | Additional volume mounts | `nil` |
+| `receiver.volumes` |Additional volumes | `nil` |
 | `ruler.enabled` | controls whether ruler related resources should be created | `true` |
 | `ruler.additionalAnnotations` | Additional annotations on ruler pod| `{}` |
 | `ruler.additionalFlags` | Additional command line flags | `{}` |
@@ -193,7 +273,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.evalInterval` | Ruler evaluation interval | `1m` |
 | `ruler.extraEnv` | Extra env vars | `nil` |
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
-| `ruler.image.tag` | Docker image tag for ruler | `v0.14.0` |
+| `ruler.image.tag` | Docker image tag for ruler | `v0.17.2` |
 | `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
 | `ruler.serviceAccount.annotations` | Service account annotations | `nil` |
 | `ruler.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
@@ -258,7 +338,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.chunkPoolSize` | Chunk pool size | `500MB` |
 | `storeGateway.extraEnv` | Extra env vars | `nil` |
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
-| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.14.0` |
+| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.17.2` |
 | `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
 | `storeGateway.indexCache.config` | Config for the index cache, see [the docs](https://thanos.io/components/store.md/#index-cache) | `max_size: 500MB` |
 | `storeGateway.indexCache.type` | Type of the index cache, either `IN-MEMORY` or `MEMCACHED` | `IN-MEMORY` |

--- a/charts/prometheus-thanos/templates/compactor/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compactor/statefulset.yaml
@@ -57,6 +57,12 @@ spec:
           {{ else if .Values.compact.objStoreConfigFile }}
           - --objstore.config-file={{ .Values.compact.objStoreConfigFile }}
           {{- end }}
+          {{- if .Values.tracingType }}
+          - |
+            --tracing.config=type: {{ .Values.tracingType }}
+            config:
+              {{- toYaml .Values.tracingConfig | nindent 14 }}
+          {{- end }}
           - --wait
           ports:
           - name: monitoring

--- a/charts/prometheus-thanos/templates/compactor/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/compactor/statefulset.yaml
@@ -57,11 +57,11 @@ spec:
           {{ else if .Values.compact.objStoreConfigFile }}
           - --objstore.config-file={{ .Values.compact.objStoreConfigFile }}
           {{- end }}
-          {{- if .Values.tracingType }}
+          {{- if .Values.tracing.enabled }}
           - |
-            --tracing.config=type: {{ .Values.tracingType }}
+            --tracing.config=type: {{ .Values.tracing.type }}
             config:
-              {{- toYaml .Values.tracingConfig | nindent 14 }}
+              {{- toYaml .Values.tracing.config | nindent 14 }}
           {{- end }}
           - --wait
           ports:

--- a/charts/prometheus-thanos/templates/querier/deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier/deployment.yaml
@@ -51,11 +51,11 @@ spec:
           {{- range $key, $value := .Values.querier.additionalFlags }}
           - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}
-          {{- if .Values.tracingType }}
+          {{- if .Values.tracing.enabled }}
           - |
-            --tracing.config=type: {{ .Values.tracingType }}
+            --tracing.config=type: {{ .Values.tracing.type }}
             config:
-              {{- toYaml .Values.tracingConfig | nindent 14 }}
+              {{- toYaml .Values.tracing.config | nindent 14 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/prometheus-thanos/templates/querier/deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier/deployment.yaml
@@ -44,7 +44,9 @@ spec:
           args:
           - query
           - --log.level={{ .Values.querier.logLevel }}
-          - --query.replica-label={{ .Values.querier.replicaLabel }}
+          {{- range .Values.querier.replicaLabels }}
+          - --query.replica-label={{ . }}
+          {{- end }}
           {{- range .Values.querier.stores }}
           - --store={{ . }}
           {{- end }}

--- a/charts/prometheus-thanos/templates/querier/deployment.yaml
+++ b/charts/prometheus-thanos/templates/querier/deployment.yaml
@@ -51,6 +51,12 @@ spec:
           {{- range $key, $value := .Values.querier.additionalFlags }}
           - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}
+          {{- if .Values.tracingType }}
+          - |
+            --tracing.config=type: {{ .Values.tracingType }}
+            config:
+              {{- toYaml .Values.tracingConfig | nindent 14 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 10902

--- a/charts/prometheus-thanos/templates/query-frontend/deployment-hpa.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/deployment-hpa.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.autoscaling.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-query-frontend
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "prometheus-thanos.fullname" . }}-query-frontend
+  minReplicas: {{ .Values.queryFrontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.queryFrontend.autoscaling.maxReplicas }}
+{{- with .Values.querier.autoscaling.metrics }}
+  metrics: 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/query-frontend/deployment.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/deployment.yaml
@@ -57,11 +57,11 @@ spec:
           {{- range $key, $value := .Values.queryFrontend.additionalFlags }}
           - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}
-          {{- if .Values.tracingType }}
+          {{- if .Values.tracing.enabled }}
           - |
-            --tracing.config=type: {{ .Values.tracingType }}
+            --tracing.config=type: {{ .Values.tracing.type }}
             config:
-              {{- toYaml .Values.tracingConfig | nindent 14 }}
+              {{- toYaml .Values.tracing.config | nindent 14 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/prometheus-thanos/templates/query-frontend/deployment.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/deployment.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.queryFrontend.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-query-frontend
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.queryFrontend.replicaCount }}
+  strategy:
+  {{- with .Values.queryFrontend.updateStrategy }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        prometheus-thanos-peer: "true"
+        {{- with .Values.queryFrontend.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "10902"
+        {{- with .Values.queryFrontend.additionalAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.queryFrontend.serviceAccount.create }}
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-query-frontend
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-query-frontend
+          imagePullPolicy: {{ .Values.queryFrontend.image.pullPolicy }}
+          image: "{{ .Values.queryFrontend.image.repository }}:{{ .Values.queryFrontend.image.tag }}"
+          args:
+          - query-frontend
+          - --log.level={{ .Values.queryFrontend.logLevel }}
+          - --query-frontend.log-queries-longer-than={{ .Values.queryFrontend.logQueriesLongerThan }}
+          - --query-range.split-interval={{ .Values.queryFrontend.querySplitInterval }}
+          {{- if .Values.queryFrontend.downstreamUrl }}
+          - --query-frontend.downstream-url={{ .Values.queryFrontend.downstreamUrl }}
+          {{- else }}
+          - --query-frontend.downstream-url=http://{{ include "prometheus-thanos.fullname" . }}-querier.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.querier.http.port }}
+          {{- end}}
+          {{- range .Values.queryFrontend.orgIdHeaders }}
+          - --query-frontend.org-id-header={{ . }}
+          {{- end }}
+          {{- range $key, $value := .Values.queryFrontend.additionalFlags }}
+          - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
+          {{- end }}
+          {{- if .Values.tracingType }}
+          - |
+            --tracing.config=type: {{ .Values.tracingType }}
+            config:
+              {{- toYaml .Values.tracingConfig | nindent 14 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: {{ .Values.queryFrontend.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.queryFrontend.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.queryFrontend.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.queryFrontend.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: {{ .Values.queryFrontend.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.queryFrontend.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.queryFrontend.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.queryFrontend.readinessProbe.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
+          {{- with .Values.queryFrontend.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+      {{- with .Values.queryFrontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.queryFrontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.queryFrontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.queryFrontend.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.queryFrontend.podNumericalPriorityEnabled }}
+      priority: {{ .Values.queryFrontend.podPriority }}
+    {{- else if .Values.queryFrontend.podPriorityClassName }}
+      priorityClassName: {{ .Values.queryFrontend.podPriorityClassName }}
+    {{- end }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/query-frontend/service.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.queryFrontend.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-query-frontend
+{{- if .Values.service.queryFrontend.annotations }}
+  annotations:
+{{ toYaml .Values.service.queryFrontend.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.queryFrontend.type }}
+  ports:
+    - port: {{ .Values.service.queryFrontend.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/query-frontend/serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-query-frontend
+{{- if .Values.queryFrontend.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.queryFrontend.serviceAccount.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-query-frontend
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/receiver/hashring-configmap.yaml
+++ b/charts/prometheus-thanos/templates/receiver/hashring-configmap.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.receiver.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thanos-receive-hashring-config
+data:
+  hashrings.json: |
+    [
+      {
+        "endpoints": [
+          {{- range $i, $e := until (int .Values.receiver.replicaCount) }}
+            "{{ include "prometheus-thanos.fullname" $ }}-receiver-{{ $i }}.{{ include "prometheus-thanos.fullname" $ }}-receiver.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.service.receiver.grpc.port }}"
+
+            {{- if lt $i (sub (int $.Values.receiver.replicaCount) 1) -}}
+            ,
+            {{- end -}}
+          {{- end }}
+        ]
+      }
+    ]
+{{- end }}

--- a/charts/prometheus-thanos/templates/receiver/service.yaml
+++ b/charts/prometheus-thanos/templates/receiver/service.yaml
@@ -1,0 +1,24 @@
+{{- /*
+See comments in ./statefulset.yaml about why this is headless
+*/}}
+
+{{- if .Values.receiver.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-receiver
+{{- if .Values.service.receiver.annotations }}
+  annotations:
+{{ toYaml .Values.service.receiver.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/receiver/serviceaccount.yaml
+++ b/charts/prometheus-thanos/templates/receiver/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.receiver.enabled .Values.receiver.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-receiver
+{{- if .Values.receiver.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.receiver.serviceAccount.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/receiver/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/receiver/statefulset.yaml
@@ -63,14 +63,12 @@ spec:
           - --remote-write.address=0.0.0.0:{{ .Values.service.receiver.httpRemoteWrite.port }}
           - --receive.local-endpoint=$(K8S_POD).$(K8S_SERVICE).$(K8S_NAMESPACE).svc.cluster.local:{{ .Values.service.receiver.grpc.port }}
           - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
-
-          {{- if .Values.tracingType }}
+          {{- if .Values.tracing.enabled }}
           - |
-            --tracing.config=type: {{ .Values.tracingType }}
+            --tracing.config=type: {{ .Values.tracing.type }}
             config:
-              {{- toYaml .Values.tracingConfig | nindent 14 }}
+              {{- toYaml .Values.tracing.config | nindent 14 }}
           {{- end }}
-
           {{- range $key, $value := .Values.receiver.additionalFlags }}
           - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}
@@ -82,7 +80,6 @@ spec:
           {{ else if .Values.receiver.objStoreConfigFile }}
           - --objstore.config-file={{ .Values.receiver.objStoreConfigFile }}
           {{- end }}
-          
           ports:
             - name: grpc
               containerPort: {{ .Values.service.receiver.grpc.port }}

--- a/charts/prometheus-thanos/templates/receiver/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/receiver/statefulset.yaml
@@ -1,0 +1,194 @@
+{{- /*
+Receivers must currently be behind a headless services since they form a hashring and communicate directly with each 
+other. This means that port mappings at the service level won't be respected, so unlike other components the port 
+overrides are defined here, rather than within the service.  In an attempt to keep some consistency (and perhaps future 
+proof for the case where it may some day be possible to map ports in headless services) the path for port values is of 
+the form '.Values.service.receiver.PORT_NAME.port'
+
+At this moment in time using the HPA to scale Receivers is not a good idea so no template has been provided.
+See https://youtu.be/5MJqdJq41Ms
+*/}}
+
+{{- if .Values.receiver.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-receiver
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.receiver.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.receiver.updateStrategy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  serviceName: {{ include "prometheus-thanos.fullname" . }}-receiver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        prometheus-thanos-peer: "true"
+        {{- with .Values.receiver.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "10902"
+        {{- with .Values.receiver.additionalAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.receiver.serviceAccount.create }}
+      serviceAccount: {{ include "prometheus-thanos.fullname" . }}-receiver
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-receiver
+          imagePullPolicy: {{ .Values.receiver.image.pullPolicy }}
+          image: "{{ .Values.receiver.image.repository }}:{{ .Values.receiver.image.tag }}"
+          args:
+          - receive
+          - --tsdb.path=/data
+          - --log.level={{ .Values.receiver.logLevel }}
+          - --receive.replication-factor={{ .Values.receiver.replicationFactor }}
+          - --label=receive_replica="$(K8S_POD)"
+          - --tsdb.retention={{ .Values.receiver.tsdbRetention }}
+          - --grpc-address=0.0.0.0:{{ .Values.service.receiver.grpc.port }}
+          - --http-address=0.0.0.0:{{ .Values.service.receiver.http.port }}
+          - --remote-write.address=0.0.0.0:{{ .Values.service.receiver.httpRemoteWrite.port }}
+          - --receive.local-endpoint=$(K8S_POD).$(K8S_SERVICE).$(K8S_NAMESPACE).svc.cluster.local:{{ .Values.service.receiver.grpc.port }}
+          - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
+
+          {{- if .Values.tracingType }}
+          - |
+            --tracing.config=type: {{ .Values.tracingType }}
+            config:
+              {{- toYaml .Values.tracingConfig | nindent 14 }}
+          {{- end }}
+
+          {{- range $key, $value := .Values.receiver.additionalFlags }}
+          - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
+          {{- end }}
+          {{- if .Values.receiver.objStoreType }}
+          - |
+            --objstore.config=type: {{ .Values.receiver.objStoreType }}
+            config:
+            {{- toYaml .Values.receiver.objStoreConfig | nindent 14 }}
+          {{ else if .Values.receiver.objStoreConfigFile }}
+          - --objstore.config-file={{ .Values.receiver.objStoreConfigFile }}
+          {{- end }}
+          
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.receiver.grpc.port }}
+              protocol: TCP
+            - name: http
+              containerPort: {{ .Values.service.receiver.http.port }}
+              protocol: TCP
+            - name: http-rw
+              containerPort: {{ .Values.service.receiver.httpRemoteWrite.port }}
+              protocol: TCP
+          
+          env:
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_POD
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE
+              value: {{ include "prometheus-thanos.fullname" . }}-receiver
+
+            {{- if .Values.receiver.extraEnv }}
+            {{- toYaml .Values.receiver.extraEnv | nindent 12 }}
+            {{- end }}
+
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: {{ .Values.receiver.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.receiver.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.receiver.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.receiver.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: {{ .Values.receiver.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.receiver.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.receiver.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.receiver.readinessProbe.timeoutSeconds }}
+          
+          resources:
+            {{- toYaml .Values.receiver.resources | nindent 12 }}
+
+          volumeMounts:
+          - mountPath: /data
+            name: storage-volume
+            readOnly: false
+          - mountPath: /var/lib/thanos-receive
+            name: hashring-config
+      
+      {{- with .Values.receiver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.receiver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.receiver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- with .Values.receiver.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if not .Values.receiver.persistentVolume.enabled }}
+        - name: storage-volume
+          emptyDir: {}
+        {{- else if .Values.receiver.persistentVolume.existingClaim }}
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.receiver.persistentVolume.existingClaim }}
+        {{- end }}
+        - name: hashring-config 
+          configMap:
+            name: thanos-receive-hashring-config
+      {{- if .Values.receiver.podNumericalPriorityEnabled }}
+      priority: {{ .Values.receiver.podPriority }}
+      {{- else if .Values.receiver.podPriorityClassName }}
+      priorityClassName: {{ .Values.receiver.podPriorityClassName }}
+      {{- end }}
+  {{- if and .Values.receiver.persistentVolume.enabled (not .Values.receiver.persistentVolume.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: storage-volume
+        {{- if .Values.receiver.persistentVolume.annotations }}
+        annotations:
+        {{- toYaml .Values.receiver.persistentVolume.annotations | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- toYaml .Values.receiver.persistentVolume.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: "{{ .Values.receiver.persistentVolume.size }}"
+        {{- if .Values.receiver.persistentVolume.storageClass }}
+        {{- if (eq "-" .Values.receiver.persistentVolume.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.receiver.persistentVolume.storageClass }}"
+        {{- end }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/ruler/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler/statefulset.yaml
@@ -64,6 +64,12 @@ spec:
 
           - --label=ruler_cluster="{{ .Values.ruler.clusterName }}"
           - --label=replica="$(POD_NAME)"
+          {{- if .Values.tracingType }}
+          - |
+            --tracing.config=type: {{ .Values.tracingType }}
+            config:
+              {{- toYaml .Values.tracingConfig | nindent 14 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/prometheus-thanos/templates/ruler/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler/statefulset.yaml
@@ -61,14 +61,13 @@ spec:
           {{- range $key, $value := .Values.ruler.additionalFlags }}
           - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}
-
           - --label=ruler_cluster="{{ .Values.ruler.clusterName }}"
           - --label=replica="$(POD_NAME)"
-          {{- if .Values.tracingType }}
+          {{- if .Values.tracing.enabled }}
           - |
-            --tracing.config=type: {{ .Values.tracingType }}
+            --tracing.config=type: {{ .Values.tracing.type }}
             config:
-              {{- toYaml .Values.tracingConfig | nindent 14 }}
+              {{- toYaml .Values.tracing.config | nindent 14 }}
           {{- end }}
           env:
             - name: POD_NAME

--- a/charts/prometheus-thanos/templates/store-gateway/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway/statefulset.yaml
@@ -60,6 +60,12 @@ spec:
           {{ else if .Values.storeGateway.objStoreConfigFile }}
           - --objstore.config-file={{ .Values.storeGateway.objStoreConfigFile }}
           {{- end }}
+          {{- if .Values.tracingType }}
+          - |
+            --tracing.config=type: {{ .Values.tracingType }}
+            config:
+              {{- toYaml .Values.tracingConfig | nindent 14 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 10902

--- a/charts/prometheus-thanos/templates/store-gateway/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway/statefulset.yaml
@@ -60,11 +60,11 @@ spec:
           {{ else if .Values.storeGateway.objStoreConfigFile }}
           - --objstore.config-file={{ .Values.storeGateway.objStoreConfigFile }}
           {{- end }}
-          {{- if .Values.tracingType }}
+          {{- if .Values.tracing.enabled }}
           - |
-            --tracing.config=type: {{ .Values.tracingType }}
+            --tracing.config=type: {{ .Values.tracing.type }}
             config:
-              {{- toYaml .Values.tracingConfig | nindent 14 }}
+              {{- toYaml .Values.tracing.config | nindent 14 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -5,6 +5,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+tracing:
+  enabled: false
+  type: ""
+  config: {}
+
 service:
   queryFrontend:
     type: ClusterIP

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -6,6 +6,11 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
+  queryFrontend:
+    type: ClusterIP
+    http:
+      port: 9090
+    annotations: {}
   querier:
     type: ClusterIP
     http:
@@ -27,11 +32,80 @@ service:
     grpc:
       port: 10901
     annotations: {}
+  receiver:
+    http:
+      port: 9090
+    httpRemoteWrite:
+      port: 9091
+    grpc:
+      port: 10901
+    annotations: {}
   bucketWebInterface:
     type: ClusterIP
     http:
       port: 9090
     annotations: {}
+
+queryFrontend:
+  enabled: true
+  replicaCount: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  image:
+    repository: quay.io/thanos/thanos
+    tag: v0.17.2
+    pullPolicy: IfNotPresent
+  serviceAccount:
+    create: false
+  #  annotations: eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+  ## See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+  ## for IAM Role for your Service Account usage
+  additionalLabels: {}
+  additionalAnnotations: {}
+  logLevel: info
+  logQueriesLongerThan: 0
+  querySplitInterval: 24h
+  additionalFlags: {}
+  resources: {}
+  nodeSelector: {}
+  podNumericalPriorityEnabled: false
+  podPriority: 0
+  podPriorityClassName: ""
+  tolerations: []
+  affinity: {}
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 30
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 30
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+    # List of MetricSpecs to decide whether to scale
+    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
 
 querier:
   enabled: true
@@ -43,7 +117,7 @@ querier:
       maxUnavailable: 0
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.14.0
+    tag: v0.17.2
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -100,7 +174,7 @@ storeGateway:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.14.0
+    tag: v0.17.2
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -184,7 +258,7 @@ compact:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.14.0
+    tag: v0.17.2
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -238,7 +312,7 @@ ruler:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.14.0
+    tag: v0.17.2
     pullPolicy: IfNotPresent
   sidecar:
     enabled: false
@@ -311,6 +385,65 @@ ruler:
   podPriority: 0
   podPriorityClassName: ""
 
+receiver:
+  enabled: true
+  replicaCount: 1
+  updateStrategy: RollingUpdate
+  image:
+    repository: quay.io/thanos/thanos
+    tag: v0.17.2
+    pullPolicy: IfNotPresent
+  serviceAccount:
+    create: false
+  additionalLabels: {}
+  additionalAnnotations: {}
+  extraEnv: []
+  logLevel: info
+  tsdbRetention: 1d
+  replicationFactor: 1
+
+  objStoreType: GCS  # WARNING: this is default to null in other sections
+  additionalFlags: {}
+  objStoreConfig: {}
+  ## GCS example
+  #  bucket: demo-bucket
+
+  ## S3 example
+  #  bucket: demo-bucket
+  #  access_key: smth
+  #  secret_key: Need8Chars
+  #  endpoint: a
+  #  insecure: true
+  objStoreConfigFile: null
+  podNumericalPriorityEnabled: false
+  podPriority: 0
+  podPriorityClassName: ""
+
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 30
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 30
+  volumeMounts:
+  volumes:
+  persistentVolume:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    annotations: {}
+    existingClaim: ""
+    size: 8Gi
+    storageClass: ""
+
 bucketWebInterface:
   enabled: false
   additionalAnnotations: {}
@@ -321,7 +454,7 @@ bucketWebInterface:
   httpServerPort: 10902
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.14.0
+    tag: v0.17.2
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -131,7 +131,7 @@ querier:
   ## for IAM Role for your Service Account usage
   additionalLabels: {}
   additionalAnnotations: {}
-  replicaLabel: replica
+  replicaLabels: []
   logLevel: info
   stores: []
   additionalFlags: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

It adds the Query Frontend and Receiver components to the chart.  
https://github.com/thanos-io/thanos/blob/master/docs/components/query-frontend.md
https://github.com/thanos-io/thanos/blob/master/docs/components/receive.md 

It also allows for simpler tracing configuration with all components which support it:
https://github.com/thanos-io/thanos/blob/master/docs/tracing.md

#### Special notes for your reviewer:

* Tested within a local `kind` cluster running k8s v1.16.15

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
