### PR TITLE
[prometheus-thanos] Add k8s Service for thanos compactor

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.17.2"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.6.1
+version: 4.7.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.17.2"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.6.0
+version: 4.6.1
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -316,6 +316,13 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `service.bucketWebInterface.type` | Service type for the bucket web interface | `ClusterIP` |
 | `service.bucketWebInterface.http.port` | Service http port for the bucket web interface  | `9090` |
 | `service.bucketWebInterface.annotations` | Service annotations for the bucket web interface  | `{}` |
+| `service.compact.type` | Service type for the compactor | `ClusterIP` |
+| `service.compact.http.port` | Service http port for the compactor | `9090` |
+| `service.compact.annotations` | Service annotations for the compactor | `{}` |
+| `service.receiver.http.port` | Service http port for the receiver | `9090` |
+| `service.receiver.httpRemoteWrite.port` | Service http port for the receiver remote write endpoint | `9091` |
+| `service.receiver.grpc.port` | Service grpc port for the receiver | `10901` |
+| `service.receiver.annotations` | Service annotations for the receiver | `{}` |
 | `service.querier.type` | Service type for the querier | `ClusterIP` |
 | `service.querier.http.port` | Service http port for the querier  | `9090` |
 | `service.querier.grpc.port` | Service grpc port for the querier  | `10901` |

--- a/charts/prometheus-thanos/templates/compactor/service.yaml
+++ b/charts/prometheus-thanos/templates/compactor/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.compact.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-thanos.fullname" . }}-compact
+{{- if .Values.service.compact.annotations }}
+  annotations:
+{{ toYaml .Values.service.compact.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-compact
+    helm.sh/chart: {{ include "prometheus-thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.compact.type }}
+  ports:
+    - port: {{ .Values.service.compact.http.port }}
+      targetPort: monitoring
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-compact
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus-thanos/templates/receiver/service.yaml
+++ b/charts/prometheus-thanos/templates/receiver/service.yaml
@@ -18,6 +18,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   clusterIP: None
+  ports:
+    - port: {{ .Values.service.receiver.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
   selector:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -50,6 +50,11 @@ service:
     http:
       port: 9090
     annotations: {}
+  compact:
+    type: ClusterIP
+    http:
+      port: 9090
+    annotations: {}
 
 queryFrontend:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Emre Kartoglu <iemrek@gmail.com>

Co-authored-by: Tony Di Nucci <tony.dinucci@skyscanner.net>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This adds a k8s Service definition for the Thanos Compactor component so we can monitor it using its HTTP `/metrics` endpoint.

This also adds a Service port mapping for the Thanos Receiver component for the same reason i.e. monitoring using the HTTP `/metrics` endpoint.

#### Special notes for your reviewer:

I've tested the changes in a local setup.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
