### PR TITLE
[prometheus-thanos] upgrade to v0.18.0

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.17.2"
+appVersion: "0.18.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.7.0
+version: 4.8.0
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -99,7 +99,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `bucketWebInterface.extraEnv` | Extra env vars | `nil` |
 | `bucketWebInterface.httpServerPort` | The port to expose from the bucket web interface container | `10902` |
 | `bucketWebInterface.image.repository` | Docker image repo for bucket web interface | `quay.io/thanos/thanos` |
-| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.17.2` |
+| `bucketWebInterface.image.tag` | Docker image tag for bucket web interface | `v0.18.0` |
 | `bucketWebInterface.image.pullPolicy` | Docker image pull policy for bucket web interface| `IfNotPresent` |
 | `bucketWebInterface.serviceAccount.create` | Create service account | `true` |
 | `bucketWebInterface.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -125,7 +125,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `compact.consistencyDelay` | Consistency delay | `30m` |
 | `compact.extraEnv` | Extra env vars | `nil` |
 | `compact.image.repository` | Docker image repo for compactor | `quay.io/thanos/thanos` |
-| `compact.image.tag` | Docker image tag for compactor | `v0.17.2` |
+| `compact.image.tag` | Docker image tag for compactor | `v0.18.0` |
 | `compact.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
 | `compact.serviceAccount.create` | Create service account | `true` |
 | `compact.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -161,7 +161,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `querier.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
 | `querier.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
 | `querier.image.repository` | Docker image repo for querier | `quay.io/thanos/thanos` |
-| `querier.image.tag` | Docker image tag for querier | `v0.17.2` |
+| `querier.image.tag` | Docker image tag for querier | `v0.18.0` |
 | `querier.image.pullPolicy` | Docker image pull policy for querier| `IfNotPresent` |
 | `querier.serviceAccount.create` | Create service account | `true` |
 | `querier.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -197,7 +197,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `queryFrontend.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
 | `queryFrontend.downstreamUrl` | The URL of the querier service | `the default URL of the querier service` |
 | `queryFrontend.image.repository` | Docker image repo for query-frontend | `quay.io/thanos/thanos` |
-| `queryFrontend.image.tag` | Docker image tag for query-frontend | `v0.17.2` |
+| `queryFrontend.image.tag` | Docker image tag for query-frontend | `v0.18.0` |
 | `queryFrontend.image.pullPolicy` | Docker image pull policy for query-frontend| `IfNotPresent` |
 | `queryFrontend.serviceAccount.create` | Create service account | `true` |
 | `queryFrontend.serviceAccount.annotations` | Service account annotations | `nil` |
@@ -230,7 +230,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `receiver.additionalLabels` | Additional labels on receiver pods| `{}` |
 | `receiver.extraEnv` | Extra env vars | `nil` |
 | `receiver.image.repository` | Docker image repo for receiver | `quay.io/thanos/thanos` |
-| `receiver.image.tag` | Docker image tag for receiver | `v0.17.2` |
+| `receiver.image.tag` | Docker image tag for receiver | `v0.18.0` |
 | `receiver.image.pullPolicy` | Docker image pull policy for receiver | `IfNotPresent` |
 | `receiver.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `receiver.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |
@@ -275,7 +275,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.evalInterval` | Ruler evaluation interval | `1m` |
 | `ruler.extraEnv` | Extra env vars | `nil` |
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
-| `ruler.image.tag` | Docker image tag for ruler | `v0.17.2` |
+| `ruler.image.tag` | Docker image tag for ruler | `v0.18.0` |
 | `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
 | `ruler.serviceAccount.annotations` | Service account annotations | `nil` |
 | `ruler.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
@@ -347,7 +347,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `storeGateway.chunkPoolSize` | Chunk pool size | `500MB` |
 | `storeGateway.extraEnv` | Extra env vars | `nil` |
 | `storeGateway.image.repository` | Docker image repo for store gateway | `quay.io/thanos/thanos` |
-| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.17.2` |
+| `storeGateway.image.tag` | Docker image tag for store gateway | `v0.18.0` |
 | `storeGateway.image.pullPolicy` | Docker image pull policy for store gateway | `IfNotPresent` |
 | `storeGateway.indexCache.config` | Config for the index cache, see [the docs](https://thanos.io/components/store.md/#index-cache) | `max_size: 500MB` |
 | `storeGateway.indexCache.type` | Type of the index cache, either `IN-MEMORY` or `MEMCACHED` | `IN-MEMORY` |

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -66,7 +66,7 @@ queryFrontend:
       maxUnavailable: 0
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -127,7 +127,7 @@ querier:
       maxUnavailable: 0
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -184,7 +184,7 @@ storeGateway:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -268,7 +268,7 @@ compact:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -322,7 +322,7 @@ ruler:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   sidecar:
     enabled: false
@@ -401,7 +401,7 @@ receiver:
   updateStrategy: RollingUpdate
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
@@ -464,7 +464,7 @@ bucketWebInterface:
   httpServerPort: 10902
   image:
     repository: quay.io/thanos/thanos
-    tag: v0.17.2
+    tag: v0.18.0
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrade Thanos to v0.18.0

#### Checklist
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
