### PR TITLE
[prometheus-thanos] Add grpc port to thanos receiver service

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.17.2"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.7.0
+version: 4.7.1
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/templates/receiver/service.yaml
+++ b/charts/prometheus-thanos/templates/receiver/service.yaml
@@ -23,6 +23,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.receiver.grpc.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: {{ include "prometheus-thanos.name" . }}-receiver
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Signed-off-by: Emre Kartoglu <iemrek@gmail.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The Service definition for Thanos Receiver did not have the grpc port listed. The port is there in the values file, and I can't think of a reason why it shouldn't be in the Service definition too, therefore I'm treating this change as a patch.

#### Notes for the reviewer:

I've tested the changes on my local kind cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
