### PR TITLE
[prometheus-thanos] Some systems (e.g. Istio) need even headless services to define ports

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.8.0
+version: 4.8.1
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/templates/receiver/service.yaml
+++ b/charts/prometheus-thanos/templates/receiver/service.yaml
@@ -23,6 +23,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.receiver.httpRemoteWrite.port }}
+      targetPort: http-rw
+      protocol: TCP
+      name: http-rw
     - port: {{ .Values.service.receiver.grpc.port }}
       targetPort: grpc
       protocol: TCP


### PR DESCRIPTION
#### What this PR does / why we need it:

Some system (e.g. Istio) depend on even headless services containing port mappings - no matter whether the mapping can change the port or not.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
