### PR TITLE
[prometheus-thanos] Add imagePullSecrets to ruler

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -5,11 +5,11 @@ name: prometheus-thanos
 version: 4.8.2
 home: https://github.com/thanos-io/thanos
 sources:
-  - https://github.com/thanos-io/thanos
-  - https://github.com/kiwigrid/helm-charts/tree/master/charts/prometheus-thanos
+- https://github.com/thanos-io/thanos
+- https://github.com/kiwigrid/helm-charts/tree/master/charts/prometheus-thanos
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
-  - name: rpahli
-    email: rico.pahlisch@kiwigrid.com
-  - name: axdotl
-    email: axel.koehler@kiwigrid.com
+- name: rpahli
+  email: rico.pahlisch@kiwigrid.com
+- name: axdotl
+  email: axel.koehler@kiwigrid.com

--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.8.1
+version: 4.8.2
 home: https://github.com/thanos-io/thanos
 sources:
-- https://github.com/thanos-io/thanos
-- https://github.com/kiwigrid/helm-charts/tree/master/charts/prometheus-thanos
+  - https://github.com/thanos-io/thanos
+  - https://github.com/kiwigrid/helm-charts/tree/master/charts/prometheus-thanos
 icon: https://raw.githubusercontent.com/thanos-io/thanos/master/docs/img/Thanos-logo_fullmedium.png
 maintainers:
-- name: rpahli
-  email: rico.pahlisch@kiwigrid.com
-- name: axdotl
-  email: axel.koehler@kiwigrid.com
+  - name: rpahli
+    email: rico.pahlisch@kiwigrid.com
+  - name: axdotl
+    email: axel.koehler@kiwigrid.com

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -276,8 +276,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.extraEnv` | Extra env vars | `nil` |
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
 | `ruler.image.tag` | Docker image tag for ruler | `v0.18.0` |
+| `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
 | `ruler.imagePullSecrets` | Docker image pull secrets for ruler | `[]` |
-`ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
 | `ruler.serviceAccount.annotations` | Service account annotations | `nil` |
 | `ruler.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `ruler.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -276,7 +276,8 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `ruler.extraEnv` | Extra env vars | `nil` |
 | `ruler.image.repository` | Docker image repo for ruler | `quay.io/thanos/thanos` |
 | `ruler.image.tag` | Docker image tag for ruler | `v0.18.0` |
-| `ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
+| `ruler.imagePullSecrets` | Docker image pull secrets for ruler | `[]` |
+`ruler.image.pullPolicy` | Docker image pull policy for ruler | `IfNotPresent` |
 | `ruler.serviceAccount.annotations` | Service account annotations | `nil` |
 | `ruler.livenessProbe.initialDelaySeconds` | Liveness probe initialDelaySeconds | `30` |
 | `ruler.livenessProbe.periodSeconds` | Liveness probe periodSeconds | `10` |

--- a/charts/prometheus-thanos/templates/ruler/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/ruler/statefulset.yaml
@@ -35,6 +35,10 @@ spec:
         {{- end }}
     spec:
       serviceAccount: {{ include "prometheus-thanos.fullname" . }}-ruler
+    {{- with .Values.ruler.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ruler
           imagePullPolicy: {{ .Values.ruler.image.pullPolicy }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -102,20 +102,20 @@ queryFrontend:
     minReplicas: 1
     maxReplicas: 10
     metrics:
-    # List of MetricSpecs to decide whether to scale
-    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+      # List of MetricSpecs to decide whether to scale
+      # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 80
 
 querier:
   enabled: true
@@ -163,20 +163,20 @@ querier:
     minReplicas: 1
     maxReplicas: 10
     metrics:
-    # List of MetricSpecs to decide whether to scale
-    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+      # List of MetricSpecs to decide whether to scale
+      # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 80
 
 storeGateway:
   enabled: true
@@ -201,7 +201,7 @@ storeGateway:
       max_size: 500MB
   chunkPoolSize: 500MB
 
-  objStoreType: GCS  # WARNING: this is default to null in other sections
+  objStoreType: GCS # WARNING: this is default to null in other sections
   additionalFlags: {}
   objStoreConfig: {}
   ## GCS example
@@ -248,20 +248,20 @@ storeGateway:
     minReplicas: 1
     maxReplicas: 10
     metrics:
-    # List of MetricSpecs to decide whether to scale
-    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+      # List of MetricSpecs to decide whether to scale
+      # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 80
 
 compact:
   enabled: true
@@ -315,7 +315,6 @@ compact:
     existingClaim: ""
     size: 10Gi
 
-
 ruler:
   enabled: true
   replicaCount: 1
@@ -332,6 +331,7 @@ ruler:
       tag: 0.1.1
       pullPolicy: IfNotPresent
   serviceAccount: {}
+  imagePullSecrets: []
   replicaLabel: replica
   logLevel: info
   ## Ruler configuration
@@ -412,7 +412,7 @@ receiver:
   tsdbRetention: 1d
   replicationFactor: 1
 
-  objStoreType: GCS  # WARNING: this is default to null in other sections
+  objStoreType: GCS # WARNING: this is default to null in other sections
   additionalFlags: {}
   objStoreConfig: {}
   ## GCS example

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -102,20 +102,20 @@ queryFrontend:
     minReplicas: 1
     maxReplicas: 10
     metrics:
-      # List of MetricSpecs to decide whether to scale
-      # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
-      - type: Resource
-        resource:
-          name: cpu
-          target:
-            type: Utilization
-            averageUtilization: 80
-      - type: Resource
-        resource:
-          name: memory
-          target:
-            type: Utilization
-            averageUtilization: 80
+    # List of MetricSpecs to decide whether to scale
+    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
 
 querier:
   enabled: true
@@ -163,20 +163,20 @@ querier:
     minReplicas: 1
     maxReplicas: 10
     metrics:
-      # List of MetricSpecs to decide whether to scale
-      # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
-      - type: Resource
-        resource:
-          name: cpu
-          target:
-            type: Utilization
-            averageUtilization: 80
-      - type: Resource
-        resource:
-          name: memory
-          target:
-            type: Utilization
-            averageUtilization: 80
+    # List of MetricSpecs to decide whether to scale
+    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
 
 storeGateway:
   enabled: true
@@ -201,7 +201,7 @@ storeGateway:
       max_size: 500MB
   chunkPoolSize: 500MB
 
-  objStoreType: GCS # WARNING: this is default to null in other sections
+  objStoreType: GCS  # WARNING: this is default to null in other sections
   additionalFlags: {}
   objStoreConfig: {}
   ## GCS example
@@ -248,20 +248,20 @@ storeGateway:
     minReplicas: 1
     maxReplicas: 10
     metrics:
-      # List of MetricSpecs to decide whether to scale
-      # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
-      - type: Resource
-        resource:
-          name: cpu
-          target:
-            type: Utilization
-            averageUtilization: 80
-      - type: Resource
-        resource:
-          name: memory
-          target:
-            type: Utilization
-            averageUtilization: 80
+    # List of MetricSpecs to decide whether to scale
+    # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#metricspec-v2beta2-autoscaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
 
 compact:
   enabled: true
@@ -314,6 +314,7 @@ compact:
     annotations: {}
     existingClaim: ""
     size: 10Gi
+
 
 ruler:
   enabled: true
@@ -412,7 +413,7 @@ receiver:
   tsdbRetention: 1d
   replicationFactor: 1
 
-  objStoreType: GCS # WARNING: this is default to null in other sections
+  objStoreType: GCS  # WARNING: this is default to null in other sections
   additionalFlags: {}
   objStoreConfig: {}
   ## GCS example


### PR DESCRIPTION
Signed-off-by: George Koufoudakis <georgios.koufoudakis@finbourne.com>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds imagePullSecrets to Thanos Ruler StatefulSet for pulling kiwigrid/k8s-configmap-watcher using  docker credentials.

#### Special notes for your reviewer:
I hope you find this useful

#### Checklist
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
