### PR TITLE
[graphite] - Add option to disable expose of the carbon UDP port

### DIFF
--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.7.3
+version: 0.8.0
 appVersion: "1.1.7-6"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.7.2
+version: 0.7.3
 appVersion: "1.1.7-6"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/README.md
+++ b/charts/graphite/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters of the Graphite chart and 
 | `service.port`                 | Service port of Graphite UI                  | `8080`                                 |
 | `service.annotations`          | Service annotations                          | `{}`                                   |
 | `service.labels`               | Service labels                               | `{}`                                   |
+| `service.enableCarbonUdpPort`  | Service Carbon UDP port enabled              | `true`                                 |
 | `persistence.enabled`          | Enable config persistence using PVC          | `true`                                 |
 | `persistence.storageClass`     | PVC Storage Class for config volume          | `nil`                                  |
 | `persistence.existingClaim`    | Name of an existing PVC to use for config    | `nil`                                  |

--- a/charts/graphite/templates/service.yaml
+++ b/charts/graphite/templates/service.yaml
@@ -23,9 +23,11 @@ spec:
     - name: graphite-plain
       port: 2003
       protocol: TCP
+      {{- if .Values.service.enableCarbonUdpPort }}
     - name: graphite-udp
       port: 2003
       protocol: UDP
+      {{- end }}
     - name: graphite-gui
       port: {{ .Values.service.port }}
       protocol: TCP

--- a/charts/graphite/templates/statefulset.yaml
+++ b/charts/graphite/templates/statefulset.yaml
@@ -33,9 +33,11 @@ spec:
           containerPort: {{ .Values.service.port }}
         - name: graphite-plain
           containerPort: 2003
+          {{- if .Values.service.enableCarbonUdpPort }}
         - name: graphite-udp
           containerPort: 2003
           protocol: UDP
+          {{- end }}
         - name: graphite-pickle
           containerPort: 2004
         - name: aggregate-plain

--- a/charts/graphite/values.yaml
+++ b/charts/graphite/values.yaml
@@ -10,7 +10,7 @@ service:
   port: 8080
   annotations: {}
   labels: {}
-  enableCarbonUdpPort: false
+  enableCarbonUdpPort: true
 
 ingress:
   enabled: false

--- a/charts/graphite/values.yaml
+++ b/charts/graphite/values.yaml
@@ -10,6 +10,7 @@ service:
   port: 8080
   annotations: {}
   labels: {}
+  enableCarbonUdpPort: false
 
 ingress:
   enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When using the graphite chart with the service type `LoadBalancer` and statsd interface type `TCP` in the GKE the following error occurs:
```
Error: Service "grafana-graphite" is invalid: ...
cannot create an external load balancer with mix protocols
```
This error occurs because GCP doesn't allow to configure load balancer with mix of the TCP and UDP protocols.

This PR adds the ability to disable exposing of the carbon UDP port by using `service.enableCarbonUdpPort` value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)