### PR TITLE
[prometheus-thanos] Allow for Thanos Receiver service to be headless or not

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.20.2"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.9.1
+version: 4.9.2
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -324,6 +324,7 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `service.receiver.httpRemoteWrite.port` | Service http port for the receiver remote write endpoint | `9091` |
 | `service.receiver.grpc.port` | Service grpc port for the receiver | `10901` |
 | `service.receiver.annotations` | Service annotations for the receiver | `{}` |
+| `service.receiver.isHeadless` | Controls whether the service above the receivers is headless  | `true` |
 | `service.querier.type` | Service type for the querier | `ClusterIP` |
 | `service.querier.http.port` | Service http port for the querier  | `9090` |
 | `service.querier.grpc.port` | Service grpc port for the querier  | `10901` |

--- a/charts/prometheus-thanos/templates/querier/deployment-hpa.yaml
+++ b/charts/prometheus-thanos/templates/querier/deployment-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.querier.enabled .Values.querier.autoscaling.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-querier

--- a/charts/prometheus-thanos/templates/query-frontend/deployment-hpa.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/deployment-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.autoscaling.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-query-frontend

--- a/charts/prometheus-thanos/templates/receiver/service.yaml
+++ b/charts/prometheus-thanos/templates/receiver/service.yaml
@@ -1,5 +1,9 @@
 {{- /*
-See comments in ./statefulset.yaml about why this is headless
+See comments in ./statefulset.yaml about configuring this as a headless service.  
+
+N.B. Some systems  (e.g. old versions of Istio) do not play well with headless services 
+so it's possible to configure this to be a standard service, rather than a headless one.
+See `service.receiver.isHeadless`
 */}}
 
 {{- if .Values.receiver.enabled -}}
@@ -17,7 +21,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  {{- if .Values.service.receiver.isHeadless }}
   clusterIP: None
+  {{- end }}
   ports:
     - port: {{ .Values.service.receiver.http.port }}
       targetPort: http

--- a/charts/prometheus-thanos/templates/receiver/statefulset.yaml
+++ b/charts/prometheus-thanos/templates/receiver/statefulset.yaml
@@ -1,9 +1,9 @@
 {{- /*
-Receivers must currently be behind a headless services since they form a hashring and communicate directly with each 
-other. This means that port mappings at the service level won't be respected, so unlike other components the port 
-overrides are defined here, rather than within the service.  In an attempt to keep some consistency (and perhaps future 
-proof for the case where it may some day be possible to map ports in headless services) the path for port values is of 
-the form '.Values.service.receiver.PORT_NAME.port'
+Receivers can typically be behind a headless services since they form a hashring and communicate directly with each 
+other. Having a headless service means that port mappings at the service level won't be respected, so unlike other 
+components the port overrides are defined here, rather than within the service.  In an attempt to keep some consistency 
+(and perhaps future proof for the case where it may some day be possible to map ports in headless services) the path for 
+port values is of the form '.Values.service.receiver.PORT_NAME.port'
 
 At this moment in time using the HPA to scale Receivers is not a good idea so no template has been provided.
 See https://youtu.be/5MJqdJq41Ms

--- a/charts/prometheus-thanos/templates/store-gateway/statefulset-hpa.yaml
+++ b/charts/prometheus-thanos/templates/store-gateway/statefulset-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.storeGateway.enabled .Values.storeGateway.autoscaling.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus-thanos.fullname" . }}-store-gateway

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -45,6 +45,7 @@ service:
     grpc:
       port: 10901
     annotations: {}
+    isHeadless: true
   bucketWebInterface:
     type: ClusterIP
     http:


### PR DESCRIPTION
Signed-off-by: Tony Di Nucci <tony.dinucci@skyscanner.net>

<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Some systems (e.g. old versions of Istio) do not like headless services.

This PR updates the chart so that headless services are still the default for Receivers (so this is not a breaking change) however you can now configure things so that a standard service is created if you want.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
