### PR TITLE
[prometheus-thanos] : Add support for query-frontend caching

### DIFF
--- a/charts/prometheus-thanos/Chart.yaml
+++ b/charts/prometheus-thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.20.2"
 description: A Helm chart for thanos monitoring components
 name: prometheus-thanos
-version: 4.9.1
+version: 4.9.2
 home: https://github.com/thanos-io/thanos
 sources:
 - https://github.com/thanos-io/thanos

--- a/charts/prometheus-thanos/README.md
+++ b/charts/prometheus-thanos/README.md
@@ -195,6 +195,9 @@ The following table lists the configurable parameters of the prometheus-thanos c
 | `queryFrontend.autoscaling.maxReplicas` | Maximum number of replicas to scale to | `10` |
 | `queryFrontend.autoscaling.minReplicas` | Minimum number of replicas to scale to | `1` |
 | `queryFrontend.autoscaling.metrics` | Array of MetricSpecs that will decide whether to scale in or out | `target of 80% for both CPU and memory resources` |
+| `queryFrontend.cache.config` | Caching configuration | `nil` |
+| `queryFrontend.cache.enabled` | Controls whether caching should be used | `false` |
+| `queryFrontend.cache.type` | Type of caching [see](https://thanos.io/tip/components/query-frontend.md/#caching) | `nil` |
 | `queryFrontend.downstreamUrl` | The URL of the querier service | `the default URL of the querier service` |
 | `queryFrontend.image.repository` | Docker image repo for query-frontend | `quay.io/thanos/thanos` |
 | `queryFrontend.image.tag` | Docker image tag for query-frontend | `v0.20.2` |

--- a/charts/prometheus-thanos/templates/query-frontend/deployment.yaml
+++ b/charts/prometheus-thanos/templates/query-frontend/deployment.yaml
@@ -54,6 +54,12 @@ spec:
           {{- range .Values.queryFrontend.orgIdHeaders }}
           - --query-frontend.org-id-header={{ . }}
           {{- end }}
+          {{- if .Values.queryFrontend.cache.enabled }}
+          - |
+            --query-range.response-cache-config="config":
+              {{- toYaml .Values.queryFrontend.cache.config | nindent 14 }}
+            "type": {{ .Values.queryFrontend.cache.type }}
+          {{- end }}
           {{- range $key, $value := .Values.queryFrontend.additionalFlags }}
           - "--{{ $key }}{{if $value }}={{ $value }}{{end}}"
           {{- end }}

--- a/charts/prometheus-thanos/values.yaml
+++ b/charts/prometheus-thanos/values.yaml
@@ -70,6 +70,8 @@ queryFrontend:
     pullPolicy: IfNotPresent
   serviceAccount:
     create: false
+  cache:
+    enabled: false
   #  annotations: eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
   ## See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
   ## for IAM Role for your Service Account usage


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds the ability to use caching in the query-frontend component


#### Which issue this PR fixes

  - I tried to get it to work using the `queryFrontend.additionalFlags` parameter, but I was constantly getting a YAML parsing error even though it was a valid YAML. These changes add specific parameters for configuring the query-frontend cache.


#### Checklist

- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
