### PR TITLE
[graphite]: fix deprecated API ingress resource #443

### DIFF
--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.7.2
+version: 0.7.3
 appVersion: "1.1.7-6"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/README.md
+++ b/charts/graphite/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the Graphite chart and 
 | `resources`                    | Resource limits for Graphite pod             | `{}`                                   |
 | `ingress.enabled`              | Ingress enabled                              | `false`                                |
 | `ingress.annotations`          | Ingress annotations                          | `{}`                                   |
-| `ingress.path`                 | Ingress path                                 | `/`                                    |
+| `ingress.className`            | Ingress class                                | `nil`                               |
 | `ingress.hosts`                | Ingress hosts                                | `[]`                                   |
 | `ingress.tls`                  | Ingress TLS                                  | `[]`                                   |
 | `resources`                    | Resources                                    | `{}`                                   |

--- a/charts/graphite/templates/ingress.yaml
+++ b/charts/graphite/templates/ingress.yaml
@@ -1,7 +1,19 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "graphite.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +27,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -26,13 +41,25 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: {{ $.Values.service.port }}
-  {{- end }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/graphite/values.yaml
+++ b/charts/graphite/values.yaml
@@ -16,9 +16,16 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /
-  hosts:
-    - chart-example.local
+  ## IngressClassName is the name of the IngressClass cluster resource. The
+  ## associated IngressClass defines which controller will implement the
+  ## resource. This replaces the deprecated `kubernetes.io/ingress.class`
+  ## annotation.
+  className: ""
+  hosts: []
+  #  - host: chart-example.local
+  #    paths:
+  #      - path: /
+  #        pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
- template ingress in all api versions and add ingress class

Signed-off-by: Daniel Boggasch <github@devconsole.de>


#### What this PR does / why we need it:
- template ingress in all api versions and add ingress class

#### Which issue this PR fixes

  - fixes #443 


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
