### PR TITLE
[error-pages] Update kubernetes ingress api to `v1`

### DIFF
--- a/charts/error-pages/Chart.yaml
+++ b/charts/error-pages/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes error pages for traefik
 name: error-pages
-version: 0.1.3
+version: 1.0.0
 home: https://github.com/kiwigrid/helm-charts
 sources:
 - https://github.com/kiwigrid/helm-charts

--- a/charts/error-pages/Chart.yaml
+++ b/charts/error-pages/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes error pages for traefik
 name: error-pages
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/kiwigrid/helm-charts
 sources:
 - https://github.com/kiwigrid/helm-charts

--- a/charts/error-pages/templates/ingress.yaml
+++ b/charts/error-pages/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "error-pages.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
We are upgrading our kubernetes cluster to v1.22 and the current chart uses a (now) deprecated kubernetes API
You can see here that it is [being deprecated](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122) and then [in this list](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#ingress-v1-networking-k8s-io) you can see that it is not being included at all

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #454 

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
