### PR TITLE
[graphite] Feature/add additional labels and annotations for statefulset

### DIFF
--- a/charts/graphite/Chart.yaml
+++ b/charts/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.0
+version: 2.2.0
 appVersion: "1.1.10-3"
 description: Graphite metrics server
 name: graphite

--- a/charts/graphite/README.md
+++ b/charts/graphite/README.md
@@ -54,6 +54,8 @@ The following table lists the configurable parameters of the Graphite chart and 
 | `ingress.path`                 | Ingress path                                 | `/`                                    |
 | `ingress.hosts`                | Ingress hosts                                | `[]`                                   |
 | `ingress.tls`                  | Ingress TLS                                  | `[]`                                   |
+| `statefulset.annotations`      | Statefulset annotations                      | `{}`                                   |
+| `statefulset.labels`           | Statefulset labels                           | `{}`                                   |
 | `resources`                    | Resources                                    | `{}`                                   |
 | `nodeSelector`                 | NodeSelector                                 | `{}`                                   |
 | `tolerations`                  | Tolerations                                  | `[]`                                   |

--- a/charts/graphite/templates/statefulset.yaml
+++ b/charts/graphite/templates/statefulset.yaml
@@ -7,6 +7,13 @@ metadata:
     helm.sh/chart: {{ include "graphite.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.statefulset.labels }}
+{{ toYaml .Values.statefulset.labels | indent 4 }}
+{{- end }}
+{{- with .Values.statefulset.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   updateStrategy:
     type: RollingUpdate

--- a/charts/graphite/values.yaml
+++ b/charts/graphite/values.yaml
@@ -24,6 +24,10 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+statefulset:
+  labels: {}
+  annotations: {}
+
 env: {}
 # - name: example-name
 #   value: example-value


### PR DESCRIPTION
<!--
Thank you for contributing to kiwigrid/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a Github Action
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds custom labels and annotations for the statefulset. This allows us to set whitelist labels used by [kubeaudit](https://github.com/Shopify/kubeaudit). 

#### Which issue this PR fixes
- none


#### Special notes for your reviewer:
We opened a PR some time ago. I've separated the changes into 2 PR's
https://github.com/kiwigrid/helm-charts/pull/447 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [x] Chart Version bumped (if the pr is an update to an existing chart)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
