### PR TITLE
upgrade helm version in deploy job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Deploy Helm chart
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_KIWIGRID_GITHUB_IO }}
-        uses: docker://kiwigrid/gcloud-kubectl-helm:2.16.1-272.0.0-184
+        uses: docker://kiwigrid/gcloud-kubectl-helm:3.11.1-421.0.0-1
         with:
           args: /github/workspace/.github/deploy-chart.sh
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR upgraded the helm chart docker image to support Helm 3 charts in this repo.
 

#### Which issue this PR fixes
- It fixes errors in the GitHub Actions
```
+ helm package /github/workspace/charts/graphite --destination /github/workspace/kiwigrid.github.io
building graphite chart...
Error: apiVersion 'v2' is not valid. The value must be "v1"
```


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://developercertificate.org) signed
- [ ] Chart Version bumped (if the pr is an update to an existing chart)
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[fluentd-elasticsearch]`)
